### PR TITLE
Added routes for stats API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ nih-nci-dceg-episphere-dev-70e8e321d62d.json
 355526_yrxqfe8i_config.json
 .vscode
 utils/notificationSpecifications.json
+functions
+firebase.json
+.firebaserc
+.DS_Store

--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -1,18 +1,220 @@
 const {BigQuery} = require('@google-cloud/bigquery');
 const bigquery = new BigQuery();
 
-const getTable = async (tableName, isParent, siteCode) => {
+const fieldMapping =  {
+    'active': 486306141,
+    'passive': 854703046,
+    'yes': 353358909,
+    'no': 104430631,
+    'notYetVerified': 875007964,
+    'outreachTimedout': 160161595,
+    'verified': 197316935,
+    'cannotBeVerified': 219863910,
+    'duplicate': 922622075
+    }
+
+
+const filterVerificationStatus = (stats, currentVerificationObj) => {
+    stats.forEach((i) => {
+        
+    if (i.verificationStatus === fieldMapping.notYetVerified) {
+        currentVerificationObj.notYetVerified = i.verificationCount
+    }
+    else if (i.verificationStatus === fieldMapping.outreachTimedout) {
+        currentVerificationObj.outreachTimedout = i.verificationCount
+    }
+    else if (i.verificationStatus === fieldMapping.verified) {
+        currentVerificationObj.verified = i.verificationCount
+    }
+    else if (i.verificationStatus === fieldMapping.cannotBeVerified) {
+        currentVerificationObj.cannotBeVerified = i.verificationCount
+    }
+    else {
+        currentVerificationObj.duplicate = i.verificationCount
+    }
+    });
+    return currentVerificationObj;
+}
+
+const getTable = async (tableName, isParent, siteCode, status, recruit) => {
     const dataset = bigquery.dataset('stats');
     const [tableData] = await dataset.table(tableName).getRows();
-    
     let data = '';
+
     if(isParent){
+        
         data = tableData.filter(dt => siteCode.indexOf(dt.siteCode) !== -1)
     }
     else {
         data = tableData.filter(dt => dt.siteCode === siteCode)
     }
-    return data
+
+    if (status === 'metricsDenominator') {
+        let metricsDenominatorObj = {}
+        let verifiedCount = 0
+        let verified = data.filter(i => 
+        ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified ) ))
+        verified.forEach((i) => {
+            verifiedCount += i.verificationCount
+        })
+        metricsDenominatorObj.verified = verifiedCount
+        data = metricsDenominatorObj
+    }
+
+    if (status === 'activeRecruits'){
+        data = data.filter(i => (i.activeCount))
+    }
+    
+    if (status === 'passiveRecruits'){
+        data = data.filter(i => (i.passiveCount))
+    }
+
+    if (status === 'activeVerification') {
+        let currentVerificationObj = {};
+        let filteredData = data.filter(i => i.recruitType === fieldMapping.active);
+        data = filterVerificationStatus(filteredData, currentVerificationObj);
+
+    }
+
+   if (status === 'passiveVerification') {
+        let currentVerificationObj = {};
+        let filteredData = data.filter(i => i.recruitType === fieldMapping.passive);
+        data = filterVerificationStatus(filteredData, currentVerificationObj);
+    }
+
+    if (status === 'VerificationDenominator') {
+        let currentObj = {};
+        let activeDenominator = data.filter(i => i.recruitType === fieldMapping.active);
+        let passiveDenominator = data.filter(i => i.recruitType === fieldMapping.passive);
+        currentObj.activeDenominator = activeDenominator[0].consentCount;
+        currentObj.passiveDenominator = passiveDenominator[0].consentCount;
+        data = currentObj; 
+    }
+
+    if (status === 'currentWorkflow' && recruit) {
+        let recruitType = fieldMapping[recruit]
+        let currentWorflowObj = {}
+        let notSignedIn = data.filter(i => (i.recruitType === recruitType && i.signedStatus === fieldMapping.no))
+        let signedIn = data.filter(i => (i.recruitType === recruitType && i.signedStatus === fieldMapping.yes && i.consentStatus === fieldMapping.no))
+        let consented = data.filter(i => (i.recruitType === recruitType && i.consentStatus === fieldMapping.yes && i.submittedStatus === fieldMapping.no))
+        let submittedProfile = data.filter(i => 
+                                (i.recruitType === recruitType && i.submittedStatus === fieldMapping.yes && (i.verificationStatus === fieldMapping.notYetVerified || i.verificationStatus === fieldMapping.outreachTimedout) ))
+        let verification = data.filter(i => 
+                                (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
+        console.log('notSignedIn', notSignedIn)
+        if (recruitType === fieldMapping.passive) currentWorflowObj.notSignedIn = 0
+        else currentWorflowObj.notSignedIn = notSignedIn[0].signedCount
+        currentWorflowObj.signedIn = signedIn[0].signedCount
+        currentWorflowObj.consented = consented[0].consentCount
+        currentWorflowObj.submittedProfile = submittedProfile[0].submittedCount
+        currentWorflowObj.verification = verification[0].verificationCount
+        data = currentWorflowObj        
+    }
+
+    if (status === 'totalCurrentWorkflow') {
+        let currentWorflowObj = {}
+        let notSignedIn = data.filter(i => ((i.recruitType === fieldMapping.active) && i.signedStatus === fieldMapping.no))
+        let signedIn = data.filter(i => ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.signedStatus === fieldMapping.yes && i.consentStatus === fieldMapping.no))
+        let consented = data.filter(i => ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.consentStatus === fieldMapping.yes && i.submittedStatus === fieldMapping.no))
+        let submittedProfile = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.submittedStatus === fieldMapping.yes && (i.verificationStatus === fieldMapping.notYetVerified || i.verificationStatus === fieldMapping.outreachTimedout) ))
+        let verification = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
+        currentWorflowObj.notSignedIn = notSignedIn[0].signedCount
+        currentWorflowObj.signedIn = signedIn[0].signedCount
+        currentWorflowObj.consented = consented[0].consentCount
+        currentWorflowObj.submittedProfile = submittedProfile[0].submittedCount
+        currentWorflowObj.verification = verification[0].verificationCount
+        data = currentWorflowObj        
+    }
+
+    if (status === 'cummulativeWorkflow' && recruit) {
+        let recruitType = fieldMapping[recruit]
+        let currentWorflowObj = {}
+        let signedInCount = 0
+        let consentedCount = 0
+        let submittedProfileCount = 0
+        let verificationCount = 0
+        let verifiedCount = 0
+
+        let signedIn = data.filter(i => 
+            (i.recruitType === recruitType && i.signedStatus === fieldMapping.yes))
+            signedIn.forEach((i) => {
+                signedInCount += i.signedCount
+            })
+        let consented = data.filter(i => 
+            (i.recruitType === recruitType && i.consentStatus === fieldMapping.yes))
+            consented.forEach((i) => {
+                consentedCount += i.consentCount
+            })
+        let submittedProfile = data.filter(i => 
+            (i.recruitType === recruitType && i.submittedStatus === fieldMapping.yes))
+            submittedProfile.forEach((i) => {
+                submittedProfileCount += i.submittedCount
+            })
+        let verification = data.filter(i => 
+            (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
+            verification.forEach((i) => {
+                verificationCount += i.verificationCount
+            })
+        
+        let verified = data.filter(i => 
+            (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified ) ))
+            verified.forEach((i) => {
+                verifiedCount += i.verificationCount
+            })
+        
+        currentWorflowObj.signedIn = signedInCount
+        currentWorflowObj.consented = consentedCount
+        currentWorflowObj.submittedProfile = submittedProfileCount
+        currentWorflowObj.verification = verificationCount
+        currentWorflowObj.verified = verifiedCount
+        data = currentWorflowObj     
+    }
+
+
+    if (status === 'totalCummulativeWorkflow') {
+        let currentWorflowObj = {}
+        let signedInCount = 0
+        let consentedCount = 0
+        let submittedProfileCount = 0
+        let verificationCount = 0
+        let verifiedCount = 0
+
+        let signedIn = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.signedStatus === fieldMapping.yes))
+              signedIn.forEach((i) => {
+                signedInCount += i.signedCount
+            })
+        let consented = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.consentStatus === fieldMapping.yes))
+             consented.forEach((i) => {
+                consentedCount += i.consentCount
+            })
+        let submittedProfile = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.submittedStatus === fieldMapping.yes))
+             submittedProfile.forEach((i) => {
+                submittedProfileCount += i.submittedCount
+            })
+        let verification = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
+             verification.forEach((i) => {
+                verificationCount += i.verificationCount
+            })
+        
+        let verified = data.filter(i => 
+            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified ) ))
+            verified.forEach((i) => {
+                verifiedCount += i.verificationCount
+            })
+        currentWorflowObj.signedIn = signedInCount
+        currentWorflowObj.consented = consentedCount
+        currentWorflowObj.submittedProfile = submittedProfileCount
+        currentWorflowObj.verification = verificationCount
+        currentWorflowObj.verified = verifiedCount
+        data = currentWorflowObj     
+    }
+    return data;
 }
 
 module.exports = {

--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -2,7 +2,7 @@ const {BigQuery} = require('@google-cloud/bigquery');
 const bigquery = new BigQuery();
 
 
-const getTable = async (tableName, isParent, siteCode, status, recruit) => {
+const getTable = async (tableName, isParent, siteCode) => {
     const dataset = bigquery.dataset('stats');
     const [tableData] = await dataset.table(tableName).getRows();
     let data = '';
@@ -13,18 +13,6 @@ const getTable = async (tableName, isParent, siteCode, status, recruit) => {
     }
     else {
         data = tableData.filter(dt => dt.siteCode === siteCode)
-    }
-
-    if (status === 'participantsRecruitsCount') {
-        return data;
-    }
-
-    if (status === 'participantsWorkflow'){
-        return data;
-    }
-
-    if (status === 'participantsVerification') {
-        return data;
     }
   
     return data;

--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -1,40 +1,6 @@
 const {BigQuery} = require('@google-cloud/bigquery');
 const bigquery = new BigQuery();
 
-const fieldMapping =  {
-    'active': 486306141,
-    'passive': 854703046,
-    'yes': 353358909,
-    'no': 104430631,
-    'notYetVerified': 875007964,
-    'outreachTimedout': 160161595,
-    'verified': 197316935,
-    'cannotBeVerified': 219863910,
-    'duplicate': 922622075
-    }
-
-
-const filterVerificationStatus = (stats, currentVerificationObj) => {
-    stats.forEach((i) => {
-        
-    if (i.verificationStatus === fieldMapping.notYetVerified) {
-        currentVerificationObj.notYetVerified = i.verificationCount
-    }
-    else if (i.verificationStatus === fieldMapping.outreachTimedout) {
-        currentVerificationObj.outreachTimedout = i.verificationCount
-    }
-    else if (i.verificationStatus === fieldMapping.verified) {
-        currentVerificationObj.verified = i.verificationCount
-    }
-    else if (i.verificationStatus === fieldMapping.cannotBeVerified) {
-        currentVerificationObj.cannotBeVerified = i.verificationCount
-    }
-    else {
-        currentVerificationObj.duplicate = i.verificationCount
-    }
-    });
-    return currentVerificationObj;
-}
 
 const getTable = async (tableName, isParent, siteCode, status, recruit) => {
     const dataset = bigquery.dataset('stats');
@@ -49,171 +15,18 @@ const getTable = async (tableName, isParent, siteCode, status, recruit) => {
         data = tableData.filter(dt => dt.siteCode === siteCode)
     }
 
-    if (status === 'metricsDenominator') {
-        let metricsDenominatorObj = {}
-        let verifiedCount = 0
-        let verified = data.filter(i => 
-        ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified ) ))
-        verified.forEach((i) => {
-            verifiedCount += i.verificationCount
-        })
-        metricsDenominatorObj.verified = verifiedCount
-        data = metricsDenominatorObj
+    if (status === 'participantsRecruitsCount') {
+        return data;
     }
 
-    if (status === 'activeRecruits'){
-        data = data.filter(i => (i.activeCount))
-    }
-    
-    if (status === 'passiveRecruits'){
-        data = data.filter(i => (i.passiveCount))
+    if (status === 'participantsWorkflow'){
+        return data;
     }
 
-    if (status === 'activeVerification') {
-        let currentVerificationObj = {};
-        let filteredData = data.filter(i => i.recruitType === fieldMapping.active);
-        data = filterVerificationStatus(filteredData, currentVerificationObj);
-
+    if (status === 'participantsVerification') {
+        return data;
     }
-
-   if (status === 'passiveVerification') {
-        let currentVerificationObj = {};
-        let filteredData = data.filter(i => i.recruitType === fieldMapping.passive);
-        data = filterVerificationStatus(filteredData, currentVerificationObj);
-    }
-
-    if (status === 'VerificationDenominator') {
-        let currentObj = {};
-        let activeDenominator = data.filter(i => i.recruitType === fieldMapping.active);
-        let passiveDenominator = data.filter(i => i.recruitType === fieldMapping.passive);
-        currentObj.activeDenominator = activeDenominator[0].consentCount;
-        currentObj.passiveDenominator = passiveDenominator[0].consentCount;
-        data = currentObj; 
-    }
-
-    if (status === 'currentWorkflow' && recruit) {
-        let recruitType = fieldMapping[recruit]
-        let currentWorflowObj = {}
-        let notSignedIn = data.filter(i => (i.recruitType === recruitType && i.signedStatus === fieldMapping.no))
-        let signedIn = data.filter(i => (i.recruitType === recruitType && i.signedStatus === fieldMapping.yes && i.consentStatus === fieldMapping.no))
-        let consented = data.filter(i => (i.recruitType === recruitType && i.consentStatus === fieldMapping.yes && i.submittedStatus === fieldMapping.no))
-        let submittedProfile = data.filter(i => 
-                                (i.recruitType === recruitType && i.submittedStatus === fieldMapping.yes && (i.verificationStatus === fieldMapping.notYetVerified || i.verificationStatus === fieldMapping.outreachTimedout) ))
-        let verification = data.filter(i => 
-                                (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
-        console.log('notSignedIn', notSignedIn)
-        if (recruitType === fieldMapping.passive) currentWorflowObj.notSignedIn = 0
-        else currentWorflowObj.notSignedIn = notSignedIn[0].signedCount
-        currentWorflowObj.signedIn = signedIn[0].signedCount
-        currentWorflowObj.consented = consented[0].consentCount
-        currentWorflowObj.submittedProfile = submittedProfile[0].submittedCount
-        currentWorflowObj.verification = verification[0].verificationCount
-        data = currentWorflowObj        
-    }
-
-    if (status === 'totalCurrentWorkflow') {
-        let currentWorflowObj = {}
-        let notSignedIn = data.filter(i => ((i.recruitType === fieldMapping.active) && i.signedStatus === fieldMapping.no))
-        let signedIn = data.filter(i => ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.signedStatus === fieldMapping.yes && i.consentStatus === fieldMapping.no))
-        let consented = data.filter(i => ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.consentStatus === fieldMapping.yes && i.submittedStatus === fieldMapping.no))
-        let submittedProfile = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.submittedStatus === fieldMapping.yes && (i.verificationStatus === fieldMapping.notYetVerified || i.verificationStatus === fieldMapping.outreachTimedout) ))
-        let verification = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
-        currentWorflowObj.notSignedIn = notSignedIn[0].signedCount
-        currentWorflowObj.signedIn = signedIn[0].signedCount
-        currentWorflowObj.consented = consented[0].consentCount
-        currentWorflowObj.submittedProfile = submittedProfile[0].submittedCount
-        currentWorflowObj.verification = verification[0].verificationCount
-        data = currentWorflowObj        
-    }
-
-    if (status === 'cummulativeWorkflow' && recruit) {
-        let recruitType = fieldMapping[recruit]
-        let currentWorflowObj = {}
-        let signedInCount = 0
-        let consentedCount = 0
-        let submittedProfileCount = 0
-        let verificationCount = 0
-        let verifiedCount = 0
-
-        let signedIn = data.filter(i => 
-            (i.recruitType === recruitType && i.signedStatus === fieldMapping.yes))
-            signedIn.forEach((i) => {
-                signedInCount += i.signedCount
-            })
-        let consented = data.filter(i => 
-            (i.recruitType === recruitType && i.consentStatus === fieldMapping.yes))
-            consented.forEach((i) => {
-                consentedCount += i.consentCount
-            })
-        let submittedProfile = data.filter(i => 
-            (i.recruitType === recruitType && i.submittedStatus === fieldMapping.yes))
-            submittedProfile.forEach((i) => {
-                submittedProfileCount += i.submittedCount
-            })
-        let verification = data.filter(i => 
-            (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
-            verification.forEach((i) => {
-                verificationCount += i.verificationCount
-            })
-        
-        let verified = data.filter(i => 
-            (i.recruitType === recruitType && (i.verificationStatus === fieldMapping.verified ) ))
-            verified.forEach((i) => {
-                verifiedCount += i.verificationCount
-            })
-        
-        currentWorflowObj.signedIn = signedInCount
-        currentWorflowObj.consented = consentedCount
-        currentWorflowObj.submittedProfile = submittedProfileCount
-        currentWorflowObj.verification = verificationCount
-        currentWorflowObj.verified = verifiedCount
-        data = currentWorflowObj     
-    }
-
-
-    if (status === 'totalCummulativeWorkflow') {
-        let currentWorflowObj = {}
-        let signedInCount = 0
-        let consentedCount = 0
-        let submittedProfileCount = 0
-        let verificationCount = 0
-        let verifiedCount = 0
-
-        let signedIn = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.signedStatus === fieldMapping.yes))
-              signedIn.forEach((i) => {
-                signedInCount += i.signedCount
-            })
-        let consented = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.consentStatus === fieldMapping.yes))
-             consented.forEach((i) => {
-                consentedCount += i.consentCount
-            })
-        let submittedProfile = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && i.submittedStatus === fieldMapping.yes))
-             submittedProfile.forEach((i) => {
-                submittedProfileCount += i.submittedCount
-            })
-        let verification = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified || i.verificationStatus === fieldMapping.cannotBeVerified || i.verificationStatus === fieldMapping.duplicate ) ))
-             verification.forEach((i) => {
-                verificationCount += i.verificationCount
-            })
-        
-        let verified = data.filter(i => 
-            ((i.recruitType === fieldMapping.active || fieldMapping.passive) && (i.verificationStatus === fieldMapping.verified ) ))
-            verified.forEach((i) => {
-                verifiedCount += i.verificationCount
-            })
-        currentWorflowObj.signedIn = signedInCount
-        currentWorflowObj.consented = consentedCount
-        currentWorflowObj.submittedProfile = submittedProfileCount
-        currentWorflowObj.verification = verificationCount
-        currentWorflowObj.verified = verifiedCount
-        data = currentWorflowObj     
-    }
+  
     return data;
 }
 

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -1,4 +1,6 @@
 const { getResponseJSON, setHeaders } = require('./shared');
+
+
 const stats = async (req, res) => {
     setHeaders(res);
 
@@ -27,7 +29,23 @@ const stats = async (req, res) => {
     if(type === 'race') response = await getTable('participants_race_count_by_sites', isParent, siteCodes);
     if(type === 'age') response = await getTable('participants_age_range_count_by_sites', isParent, siteCodes);
     if(type === 'sex') response = await getTable('participants_sex_count_by_sites', isParent, siteCodes);
-    
+    if(type === 'metrics_denominator') response = await getTable('participants_workflow_status', isParent, siteCodes, 'metricsDenominator'); 
+
+    if(type === 'active_verification_status') response = await getTable('participants_verification_status', isParent, siteCodes, 'activeVerification');
+    if(type === 'verification_status_denominator') response = await getTable('participant_verification_status_denominator', isParent, siteCodes, 'VerificationDenominator');
+    if(type === 'passive_verification_status') response = await getTable('participants_verification_status', isParent, siteCodes, 'passiveVerification');
+
+    if(type === 'active_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'currentWorkflow', 'active'); 
+    if(type === 'passive_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'currentWorkflow', 'passive'); 
+    if(type === 'total_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'totalCurrentWorkflow'); 
+
+    if(type === 'active_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'cummulativeWorkflow', 'active'); 
+    if(type === 'passive_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'cummulativeWorkflow', 'passive');
+    if(type === 'total_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'totalCummulativeWorkflow'); 
+
+    if(type === 'active_recruits') response = await getTable('participants_active_recruits', isParent, siteCodes, 'activeRecruits');
+    if(type === 'passive_recruits') response = await getTable('participants_passive_recruits', isParent, siteCodes, 'passiveRecruits');
+
     return res.status(200).json({stats: response, code:200});
 }
 

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -29,22 +29,12 @@ const stats = async (req, res) => {
     if(type === 'race') response = await getTable('participants_race_count_by_sites', isParent, siteCodes);
     if(type === 'age') response = await getTable('participants_age_range_count_by_sites', isParent, siteCodes);
     if(type === 'sex') response = await getTable('participants_sex_count_by_sites', isParent, siteCodes);
-    if(type === 'metrics_denominator') response = await getTable('participants_workflow_status', isParent, siteCodes, 'metricsDenominator'); 
+    
+    if(type === 'participants_verification') response = await getTable('participants_verification_status', isParent, siteCodes, 'participantVerification');
+    if(type === 'participants_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'participantsWorkflow');
 
-    if(type === 'active_verification_status') response = await getTable('participants_verification_status', isParent, siteCodes, 'activeVerification');
-    if(type === 'verification_status_denominator') response = await getTable('participant_verification_status_denominator', isParent, siteCodes, 'VerificationDenominator');
-    if(type === 'passive_verification_status') response = await getTable('participants_verification_status', isParent, siteCodes, 'passiveVerification');
+    if(type === 'participants_recruits_count') response = await getTable('participants_recruits_count', isParent, siteCodes, 'participantsRecruitsCount');
 
-    if(type === 'active_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'currentWorkflow', 'active'); 
-    if(type === 'passive_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'currentWorkflow', 'passive'); 
-    if(type === 'total_participant_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'totalCurrentWorkflow'); 
-
-    if(type === 'active_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'cummulativeWorkflow', 'active'); 
-    if(type === 'passive_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'cummulativeWorkflow', 'passive');
-    if(type === 'total_cummulative_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'totalCummulativeWorkflow'); 
-
-    if(type === 'active_recruits') response = await getTable('participants_active_recruits', isParent, siteCodes, 'activeRecruits');
-    if(type === 'passive_recruits') response = await getTable('participants_passive_recruits', isParent, siteCodes, 'passiveRecruits');
 
     return res.status(200).json({stats: response, code:200});
 }

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -30,10 +30,10 @@ const stats = async (req, res) => {
     if(type === 'age') response = await getTable('participants_age_range_count_by_sites', isParent, siteCodes);
     if(type === 'sex') response = await getTable('participants_sex_count_by_sites', isParent, siteCodes);
     
-    if(type === 'participants_verification') response = await getTable('participants_verification_status', isParent, siteCodes, 'participantVerification');
-    if(type === 'participants_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes, 'participantsWorkflow');
+    if(type === 'participants_verification') response = await getTable('participants_verification_status', isParent, siteCodes);
+    if(type === 'participants_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes,);
 
-    if(type === 'participants_recruits_count') response = await getTable('participants_recruits_count', isParent, siteCodes, 'participantsRecruitsCount');
+    if(type === 'participants_recruits_count') response = await getTable('participants_recruits_count', isParent, siteCodes);
 
 
     return res.status(200).json({stats: response, code:200});


### PR DESCRIPTION
This PR addresses the following features:
-> Stats API is extended, more info on notes. The API returns JSON response from Participant_Workflow, Participant_Verification, Participant_Recruits_Count DB.

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [x] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/stats?type=participants_workflow**_ returns cumulative or current workflow
_**http://{URL}/stats?type=participants_verification**_ returns verification status of the users
_**http://{URL}/stats?type=participants_recruits_count**_ returns active or passive recruits count

**Test cases:**

**-> participants_recruits_count for SITE A:**
 <img width="1342" alt="Screen Shot 2021-03-26 at 12 56 01 AM" src="https://user-images.githubusercontent.com/30497847/112584350-12048e80-8dce-11eb-8dca-43b9710625b4.png">
**-> participants_recruits_count for SITE B:**
<img width="1410" alt="Screen Shot 2021-03-26 at 1 00 13 AM" src="https://user-images.githubusercontent.com/30497847/112584671-a1aa3d00-8dce-11eb-9999-691502923eea.png">


