### PR TITLE
Updated Metrics Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ functions
 firebase.json
 .firebaserc
 .DS_Store
+firebase-debug.log
+ui-debug.log

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -26,11 +26,13 @@ const stats = async (req, res) => {
     const type = req.query.type;
     const { getTable } = require('./bigquery');
     let response
-    if(type === 'race') response = await getTable('participants_race_count_by_sites', isParent, siteCodes);
-    if(type === 'age') response = await getTable('participants_age_range_count_by_sites', isParent, siteCodes);
-    if(type === 'sex') response = await getTable('participants_sex_count_by_sites', isParent, siteCodes);
+    if(type === 'race') response = await getTable('participants_race_by_siteCode', isParent, siteCodes);
+    if(type === 'age') response = await getTable('participants_age_by_siteCode', isParent, siteCodes);
+    if(type === 'sex') response = await getTable('participants_gender_by_siteCode', isParent, siteCodes);
+
     if(type === 'participants_verification') response = await getTable('participants_verification_status', isParent, siteCodes);
     if(type === 'participants_workflow') response = await getTable('participants_workflow_status', isParent, siteCodes);
+
     if(type === 'participants_recruits_count') response = await getTable('participants_recruits_count', isParent, siteCodes);
 
     return res.status(200).json({stats: response, code:200});


### PR DESCRIPTION
This PR addresses the following features:
-> Stats API for metrics is updated to a new tables. The API returns JSON response from `participants_race_by_siteCode, participants_age_by_siteCode, participants_gender_by_siteCode
`
Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [x] Any dependencies or modules added
- [x] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/stats?type=race**_ returns race response
_**http://{URL}/stats?type=age**_ returns age response
_**http://{URL}/stats?type=sex**_ returns gender response

**Test cases:**

**-> Age response for SITE A:**
<img width="1291" alt="Screen Shot 2021-03-31 at 8 13 53 AM" src="https://user-images.githubusercontent.com/30497847/113142665-26df8880-91f9-11eb-8f4c-bee96b8da141.png">

**->Age response for SITE B:**
<img width="1286" alt="Screen Shot 2021-03-31 at 8 19 08 AM" src="https://user-images.githubusercontent.com/30497847/113143122-c735ad00-91f9-11eb-9803-5d806ccd63c1.png">



