### PR TITLE
Update age range table

### DIFF
--- a/utils/stats.js
+++ b/utils/stats.js
@@ -27,7 +27,7 @@ const stats = async (req, res) => {
     const { getTable } = require('./bigquery');
     let response
     if(type === 'race') response = await getTable('participants_race_count_by_sites', isParent, siteCodes);
-    if(type === 'age') response = await getTable('participants_age_range_count_by_sites', isParent, siteCodes);
+    if(type === 'age') response = await getTable('participant_birthYear_by_siteCode', isParent, siteCodes );
     if(type === 'sex') response = await getTable('participants_sex_count_by_sites', isParent, siteCodes);
 
     if(type === 'participants_verification') response = await getTable('participants_verification_status', isParent, siteCodes);


### PR DESCRIPTION
Birth year is used to calculate the age range. Once data is available would be swapped out with `participants_age_range_count_by_sites` table.
Related PRs: #10 #9 