### PR TITLE
BPTL Dashboard: Added Participant Selection APIs

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -322,6 +322,46 @@ const biospecimenAPIs = async (req, res) => {
         return res.status(200).json({data: response, code:200})
     }
 
+     // Participant Selection with filter GET- BPTL 
+    else if(api === 'getParticipantSelection') {
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        const query = req.query.type;
+        if(Object.keys(query).length === 0) return res.status(404).json(getResponseJSON('Please include parameter to filter data.', 400));
+        const { getParticipantSelection } = require('./firestore');
+        const response = await getParticipantSelection(query);
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        console.log('res', response)
+        return res.status(200).json({data: response, code:200})
+    }
+
+     // Print Addresses POST- BPTL
+    else if(api == 'printAddresses'){
+        if(req.method !== 'POST') {
+            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+        }
+        let requestData = req.body;
+        if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+        const { addPrintAddressesParticipants } = require('./firestore');
+        const response = await addPrintAddressesParticipants(requestData);
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        return res.status(200).json({message: `Success!`, code:200})
+    }
+
+    // Print Addresses POST- BPTL
+    else if(api == 'assignKit'){
+        if(req.method !== 'POST') {
+            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+        }
+        let requestData = req.body;
+        if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+        const { assignKitToParticipants } = require('./firestore');
+        const response = await assignKitToParticipants(requestData);
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        return res.status(200).json({message: `Success!`, code:200})
+    }
+
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 };
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1345,6 +1345,55 @@ const getSiteEmail = async (siteCode) => {
     }
 }
 
+const addPrintAddressesParticipants = async (data) => {
+    try {
+        const uuid = require('uuid');
+        const assignedUUID = uuid();
+        const currentDate = new Date().toISOString();
+        const batch = db.batch();
+        await data.map(async (i) => {
+           i.id = assignedUUID;
+           i.time_stamp = currentDate;
+           const docRef = await db.collection('participantSelection').doc(assignedUUID);
+           batch.set(docRef, i);
+         });
+        await batch.commit();
+        return true;
+    }
+    catch(error){
+        return new Error(error);
+    }
+}
+
+const getParticipantSelection = async (filter) => {
+    try {
+        const snapshot = await db.collection("participantSelection")
+                                 .where('kit_status', '==', filter)
+                                 .get();
+        return snapshot.docs.map(doc => doc.data()) 
+    }
+    catch(error){
+        return new Error(error);
+    }
+}
+
+
+const assignKitToParticipants = async (data) => {
+    try {
+        await db.collection("participantSelection").doc(data.id).update(
+            { 
+                kit_status: "assigned",
+                usps_trackingNum: data.usps_trackingNum,
+                supply_kitId: data.supply_kitId
+
+            })
+        return true;
+        }
+    catch(error){
+        return new Error(error);
+    }
+}
+
 module.exports = {
     updateResponse,
     validateSiteUser,
@@ -1415,5 +1464,8 @@ module.exports = {
     storeSiteNotifications,
     getCoordinatingCenterEmail,
     getSiteEmail,
-    retrieveSiteNotifications
+    retrieveSiteNotifications,
+    addPrintAddressesParticipants,
+    getParticipantSelection,
+    assignKitToParticipants
 }


### PR DESCRIPTION
This PR addresses following feature:
-> Added POST & GET endpoint for Participant Selection

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [x] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/biospecimen?api=printAddresses**_ returns success upon adding participant data to Participant Selection collection
_**http://{URL}/biospecimen?api=getParticipantSelection&type=${filter}**_ returns participant data with kit status set as per  filter
_**http://{URL}/biospecimen?api=assignKit**_ updates participant data with kit status, usps tracking number & supply kit id

