### PR TITLE
 BPTL Dashboard: Added endpoints for package receipt & bptl metrics

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -375,6 +375,30 @@ const biospecimenAPIs = async (req, res) => {
         return res.status(200).json({message: `Success!`, code:200})
         }
 
+    // Store Receipt POST- BPTL 
+    else if(api === 'storeReceipt') {
+            if(req.method !== 'POST') {
+                return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+            }
+            let requestData = req.body;
+            if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+            const { storePackageReceipt } = require('./firestore');
+            const response = await storePackageReceipt(requestData);
+            if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+            return res.status(200).json({message: `Success!`, code:200});
+        }
+
+    // BPTL Metrics GET- BPTL 
+    else  if(api === 'bptlMetrics') {
+            if(req.method !== 'GET') {
+                return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+            }
+            const { getBptlMetrics } = require('./firestore');
+            const response = await getBptlMetrics();
+            if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+            return res.status(200).json({data: response, code:200})
+        }
+
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 };
 


### PR DESCRIPTION
This PR addresses following feature:
-> Added POST endpoint for package receipt
-> Added GET endpoint for bptl metrics

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/biospecimen?api=storeReceipt**_ stores package receipts information for participants
_**http://{URL}/biospecimen?api=bptlMetrics**_ returns BPTL metrics
