### PR TITLE
BPTL Dashboard: Added BPTL Metrics API endpoint

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -399,7 +399,7 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(200).json({data: response, code:200})
         }
 
-    // BPTL Metrics Shipped KitGET- BPTL 
+    // BPTL Metrics Shipped Kit GET
     else  if(api === 'bptlMetricsShipped') {
         if(req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -399,6 +399,17 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(200).json({data: response, code:200})
         }
 
+    // BPTL Metrics Shipped KitGET- BPTL 
+    else  if(api === 'bptlMetricsShipped') {
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        const { getBptlMetricsForShipped } = require('./firestore');
+        const response = await getBptlMetricsForShipped();
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        return res.status(200).json({data: response, code:200})
+    }
+
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 };
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1497,6 +1497,26 @@ const getBptlMetrics = async () => {
     return snapshot.docs.map(doc => doc.data())
 }
 
+const getBptlMetricsForShipped = async () => {
+    try {
+        let response = []
+        const snapshot = await db.collection("participantSelection").where('kit_status', '==', 'shipped').get();
+        let shipedParticipants = snapshot.docs.map(doc =>  doc.data())
+        const keys = ['first_name', 'last_name', 'pickup_date', 'participation_status']
+        shipedParticipants.forEach( i => { response.push(pick(i, keys) )});
+        return response;
+        }
+
+    catch(error){
+        return new Error(error);
+    }
+}
+
+const pick = (obj, arr) => {
+    return arr.reduce((acc, record) => (record in obj && (acc[record] = obj[record]), acc), {})
+} 
+
+
 
 module.exports = {
     updateResponse,
@@ -1574,5 +1594,6 @@ module.exports = {
     assignKitToParticipants,
     shipKits,
     storePackageReceipt,
-    getBptlMetrics
+    getBptlMetrics,
+    getBptlMetricsForShipped
 }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1407,7 +1407,8 @@ const assignKitToParticipants = async (data) => {
                 supply_kitId: data.supply_kitId,
                 collection_cardId: data.collection_cardId,
                 collection_cupId: data.collection_cupId,
-                specimen_kitId: data.specimen_kitId
+                specimen_kitId: data.specimen_kitId,
+                specimen_kit_usps_trackingNum: data.specimen_kit_usps_trackingNum
             })
             await kitStatusCounterVariation('assigned', 'addressPrinted');
             return true;


### PR DESCRIPTION
This PR addresses following feature:
-> Added GET endpoint for BPTL metrics
-> Endpoint returns list of participants with kit status = shipped

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/biospecimen?api=bptlMetricsShipped**_ returns list of participants with kit status = shipped

