### PR TITLE
BPTL Dashboard: Added BSI endpoint & modified setPackageReceiptFedex

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -410,6 +410,19 @@ const biospecimenAPIs = async (req, res) => {
         return res.status(200).json({data: response, code:200})
     }
 
+    else if (api === 'queryBsiData') {
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        const query = req.query.type;
+        console.log('qqqq', query)
+        if(Object.keys(query).length === 0) return res.status(404).json(getResponseJSON('Please include parameter to filter data.', 400));
+        const { getQueryBsiData } = require('./firestore');
+        const response = await getQueryBsiData(query);
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        return res.status(200).json({data: response, code:200})
+    }
+
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 };
 

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -399,6 +399,17 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(200).json({data: response, code:200})
         }
 
+    // BPTL Metrics Shipped KitGET- BPTL 
+    else  if(api === 'bptlMetricsShipped') {
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        const { getBptlMetricsForShipped } = require('./firestore');
+        const response = await getBptlMetricsForShipped();
+        if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
+        return res.status(200).json({data: response, code:200})
+    }
+
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 };
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1295,6 +1295,7 @@ const getNotificationsCategories = async () => {
 
 const addKitAssemblyData = async (data) => {
     try {
+        data['supplyKitIdUtilized'] = false
         await db.collection('kitAssembly').add(data);
         return true;
     }
@@ -1386,7 +1387,7 @@ const getParticipantSelection = async (filter) => {
 
 const assignKitToParticipants = async (data) => {
     try {
-        const snapshot = await db.collection("kitAssembly").where('supplyKitId', '==', data.supply_kitId).where('used', '==', false).get();
+        const snapshot = await db.collection("kitAssembly").where('supplyKitId', '==', data.supply_kitId).where('supplyKitIdUtilized', '==', false).get();
         if (Object.keys(snapshot.docs).length !== 0) {
             snapshot.docs.map(doc => {
                 data['collection_cardId'] = doc.data().collectionCardId
@@ -1397,7 +1398,7 @@ const assignKitToParticipants = async (data) => {
             const docId = snapshot.docs[0].id;
             await db.collection("kitAssembly").doc(docId).update(
             { 
-                used: true
+                supplyKitIdUtilized: true
             })
             await db.collection("participantSelection").doc(data.id).update(
             { 
@@ -1447,7 +1448,7 @@ const storePackageReceipt =  (data) => {
 
 const setPackageReceiptUSPS = async (data) => {
     try {
-        const snapshot = await db.collection("participantSelection").where('usps_trackingNum', '==', parseInt(data.scannedBarcode)).get();
+        const snapshot = await db.collection("participantSelection").where('usps_trackingNum', '==', data.scannedBarcode).get();
         const docId = snapshot.docs[0].id;
         await db.collection("participantSelection").doc(docId).update(
         { 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1497,6 +1497,26 @@ const getBptlMetrics = async () => {
     return snapshot.docs.map(doc => doc.data())
 }
 
+const getBptlMetricsForShipped = async () => {
+    try {
+        let response = []
+        const snapshot = await db.collection("participantSelection").where('kit_status', '==', 'shipped').get();
+        let shipedParticipants = snapshot.docs.map(doc =>  doc.data())
+        const keys = ['first_name', 'last_name', 'pickup_date', 'participation_status']
+        shipedParticipants.forEach( i => { response.push(pick(i, keys) )});
+        return response;
+        }
+
+    catch(error){
+        return new Error(error);
+    }
+}
+
+const pick = (obj, arr) => {
+    return arr.reduce((acc, record) => (record in obj && (acc[record] = obj[record]), acc), {})
+} 
+
+
 
 module.exports = {
     updateResponse,
@@ -1574,5 +1594,6 @@ module.exports = {
     assignKitToParticipants,
     shipKits,
     storePackageReceipt,
-    getBptlMetrics
+    getBptlMetrics,
+    getBptlMetricsForShipped
 }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1407,7 +1407,8 @@ const assignKitToParticipants = async (data) => {
                 supply_kitId: data.supply_kitId,
                 collection_cardId: data.collection_cardId,
                 collection_cupId: data.collection_cupId,
-                specimen_kitId: data.specimen_kitId
+                specimen_kitId: data.specimen_kitId,
+                specimen_kit_usps_trackingNum: data.specimen_kit_usps_trackingNum
             })
             await kitStatusCounterVariation('assigned', 'addressPrinted');
             return true;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1611,6 +1611,10 @@ const getQueryBsiData = async (query) => {
         return new Error(error);
     }
 }
+const getRestrictedFields = async () => {
+    const snapshot = await db.collection('siteDetails').where('coordinatingCenter', '==', true).get();
+    return snapshot.docs[0].data().restrictedFields;
+}
 
 module.exports = {
     updateResponse,
@@ -1690,5 +1694,6 @@ module.exports = {
     storePackageReceipt,
     getBptlMetrics,
     getBptlMetricsForShipped,
-    getQueryBsiData
+    getQueryBsiData,
+    getRestrictedFields
 }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -503,6 +503,28 @@ const initializeTimestamps = {
     }
 }
 
+const collectionIdConversion = {
+    "0007": "143615646",
+    "0009": "223999569",
+    "0012": "232343615",
+    "0001": "299553921",
+    "0011": "376960806",
+    "0004": "454453939",
+    "0021": "589588440",
+    "0005": "652357376",
+    "0032": "654812257",
+    "0014": "677469051",
+    "0024": "683613884",
+    "0002": "703954371",
+    "0022": "746999767",
+    "0008": "787237543",
+    "0003": "838567176",
+    "0031": "857757831",
+    "0013": "958646668",
+    "0006": "973670172"
+}
+
+
 module.exports = {
     getResponseJSON,
     setHeaders,
@@ -524,5 +546,6 @@ module.exports = {
     conceptMappings,
     logIPAdddress,
     decodingJWT,
-    initializeTimestamps
+    initializeTimestamps,
+    collectionIdConversion
 }


### PR DESCRIPTION
This PR addresses following feature:
-> Added GET endpoint for BPTL BSI endpoint
-> Endpoint returns BSI data which is stored in CSV file

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added
- [ ] Attach PoC
- [x] Notes added

**Notes:**

_**http://{URL}/biospecimen?api=queryBsiData**_ returns list of participants with kit status = shipped

