### PR TITLE
bug fix to update doc instead of add another

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -140,10 +140,8 @@ const biospecimenAPIs = async (req, res) => {
                 const exists = await specimenExists(masterSpecimenId, specimen)
                 if(exists === false) return res.status(400).json(getResponseJSON('Specimen does not exist!', 400));
                 if(exists === true){
-                    const uuid = require('uuid');
-                    specimen['id'] = uuid();
-                    const { storeSpecimen } = require('./firestore');
-                    await storeSpecimen(specimen);
+                    const { updateSpecimen } = require('./firestore');
+                    await updateSpecimen(masterSpecimenId, specimen);
                     return res.status(200).json({message: 'Success!', code:200});
                 }
             }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -742,6 +742,11 @@ const storeSpecimen = async (data) => {
     await db.collection('biospecimen').add(data);
 }
 
+const updateSpecimen = async (id, data) => {
+    const snapshot = await db.collection('biospecimen').where('820476880', '==', id).get();
+    const docId = snapshot.docs[0].id;
+    await db.collection('biospecimen').doc(docId).update(data);
+}
 
 const storeBox = async (data) => {
     await db.collection('boxes').add(data);
@@ -1643,6 +1648,7 @@ module.exports = {
     addNewBiospecimenUser,
     removeUser,
     storeSpecimen,
+    updateSpecimen,
     searchSpecimen,
     searchShipments,
     specimenExists,


### PR DESCRIPTION
There was a bug with the previous code that was adding another document instead of updating the existing one. The following changes were made:

* created updateSpecimen() function in firestorm.js - this function has the code that we previously deleted from specimenExists() where it updates the collection snapshot
* in the updateSpecimen case on biospecimen.js if we return true on specimenExists() then we call the new updateSpecimen() function instead of the storeSpecimen() function which would create a new record