### PR TITLE
SIteManager Dashboard: Added endpoint for biospecimen chart metrics

### DIFF
--- a/utils/stats.js
+++ b/utils/stats.js
@@ -54,6 +54,7 @@ const stats = async (req, res, authObj) => {
     if(type === 'participants_modulesTwoThree') response = await getTable('participants_modulesTwoThree', isParent, siteCodes);
 
     if(type === 'participants_ssn') response = await getTable('participants_ssn', isParent, siteCodes);
+    if(type === 'participants_biospecimen') response = await getTable('participants_biospecimen', isParent, siteCodes);
 
     return res.status(200).json({stats: response, code:200});
 }


### PR DESCRIPTION
This PR addresses following feature:
-> Added API endpoint for Biospecimen Metrics
Endpoint: {baseAPI}/dashboard?api=stats&type=participants_biospecimen
