### PR TITLE
Add logic to setPackageReceiptsFedex to handle a bag with three scanned concepts

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1541,7 +1541,7 @@ const setPackageReceiptFedex = async (data) => {
                     if (bag in collectionIdKeys){
                         if (collectionIdKeys[bag]['787237543'] !== undefined || collectionIdKeys[bag]['223999569'] !== undefined || collectionIdKeys[bag]['522094118'] !== undefined) {
                             let storeCollectionId = ``
-                            if (collectionIdKeys[bag]['787237543']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['787237543'].split(' ')[0] 
+                            if (collectionIdKeys[bag]['787237543']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['787237543'].split(' ')[0]
                             if (collectionIdKeys[bag]['223999569']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['223999569'].split(' ')[0]
                             if (collectionIdKeys[bag]['522094118']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['522094118'].split(' ')[0]
                             const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', storeCollectionId).get(); // find related biospecimen using collection id

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1541,9 +1541,9 @@ const setPackageReceiptFedex = async (data) => {
                     if (bag in collectionIdKeys){
                         if (collectionIdKeys[bag]['787237543'] !== undefined || collectionIdKeys[bag]['223999569'] !== undefined || collectionIdKeys[bag]['522094118'] !== undefined) {
                             let storeCollectionId = ``
-                            if (collectionIdKeys[bag]['787237543']) storeCollectionId =  collectionIdKeys[bag]['787237543'].split(' ')[0]
-                            if (collectionIdKeys[bag]['223999569']) storeCollectionId =  collectionIdKeys[bag]['223999569'].split(' ')[0]
-                            if (collectionIdKeys[bag]['522094118']) storeCollectionId =  collectionIdKeys[bag]['522094118'].split(' ')[0]
+                            if (collectionIdKeys[bag]['787237543']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['787237543'].split(' ')[0] 
+                            if (collectionIdKeys[bag]['223999569']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['223999569'].split(' ')[0]
+                            if (collectionIdKeys[bag]['522094118']) storeCollectionId =  storeCollectionId || collectionIdKeys[bag]['522094118'].split(' ')[0]
                             const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', storeCollectionId).get(); // find related biospecimen using collection id
                             const docId = secondSnapshot.docs[0].id; // grab the docID to update the biospecimen
                             let getBiospecimenDataObject = await db.collection("biospecimen").doc(docId).get();


### PR DESCRIPTION
This PR addressese the following: 
- add logic to setPackageReceiptsFedex to handle a bag with three scanned concepts added
- a blood/urine,mouthwash or orphan will have a collection value and the remaining two will be an empty string