### PR TITLE
Adding Refusal / Withdrawal Type to getParticipants API

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -369,6 +369,24 @@ const retrieveParticipants = async (siteCode, decider, isParent, limit, page, si
             if(to) query = query.where('914594314', '<=', to)
             participants = await query.get();
         }
+        if(decider === 'refusalswithdrawals') {
+            let query = db.collection('participants');
+            
+            //if(from || to) query = query.orderBy("", "desc");
+
+            query = query.where("512820379", "==", 854703046)
+                            .orderBy("821247024", "asc")
+                            .offset(offset)
+                            .limit(limit)
+            
+            if(site) query = query.where('827220437', '==', site);
+            else query = query.where('827220437', operator, siteCode);
+
+            //if(from) query = query.where('TBD', '>=', from);
+            //if(to) query = query.where('TBD', '<=', to);
+            
+            participants = await query.get();
+        }
         return participants.docs.map(document => {
             let data = document.data();
             return data;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -369,24 +369,6 @@ const retrieveParticipants = async (siteCode, decider, isParent, limit, page, si
             if(to) query = query.where('914594314', '<=', to)
             participants = await query.get();
         }
-        if(decider === 'refusalswithdrawals') {
-            let query = db.collection('participants');
-            
-            //if(from || to) query = query.orderBy("", "desc");
-
-            query = query.where("512820379", "==", 854703046)
-                            .orderBy("821247024", "asc")
-                            .offset(offset)
-                            .limit(limit)
-            
-            if(site) query = query.where('827220437', '==', site);
-            else query = query.where('827220437', operator, siteCode);
-
-            //if(from) query = query.where('TBD', '>=', from);
-            //if(to) query = query.where('TBD', '<=', to);
-            
-            participants = await query.get();
-        }
         return participants.docs.map(document => {
             let data = document.data();
             return data;
@@ -395,6 +377,28 @@ const retrieveParticipants = async (siteCode, decider, isParent, limit, page, si
     catch(error){
         console.error(error);
         return new Error(error);
+    }
+}
+
+const retrieveRefusalWithdrawalParticipants = async (siteCode, isParent, concept, limit, page) => {
+    try {
+        const operator = isParent ? 'in' : '==';
+        const offset = (page - 1) * limit;
+        
+        let participants = await db.collection('participants')
+                                .where('827220437', operator, siteCode)
+                                .where(concept, '==', 353358909)
+                                .orderBy('Connect_ID', 'asc')
+                                .offset(offset)
+                                .limit(limit)
+                                .get();                 
+
+        return participants.docs.map(document => {
+            return document.data();
+        });
+    } catch (error) {
+        console.error(error);
+        return new Error(error)
     }
 }
 
@@ -1961,5 +1965,6 @@ module.exports = {
     getQueryBsiData,
     getRestrictedFields,
     sendClientEmail,
-    verifyUsersEmailOrPhone
+    verifyUsersEmailOrPhone,
+    retrieveRefusalWithdrawalParticipants
 }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -292,6 +292,25 @@ const retentionConcepts = [
     '454445267', // consent datetime
 ]
 
+const refusalWithdrawalConcepts = {
+    "refusedBaselineBlood": "685002411.194410742",
+    "refusedBaselineSpecimenSurvey": "685002411.217367618",
+    "refusedBaselineSaliva": "685002411.277479354",
+    "refusedFutureSamples": "685002411.352996056",
+    "refusedFutureSurveys": "685002411.867203506",
+    "refusedBaselineUrine": "685002411.949501163",
+    "refusedBaselineSurveys": "685002411.994064239",
+
+    "suspendedContact": "726389747",
+    "withdrewConsent": "747006172",
+    "revokeHIPAA": "773707518",
+    "dataDestroyed": "831041022",
+    "refusedFutureActivities": "906417725",
+    "deceased": "987563196",
+
+    "anyRefusalWithdrawal": "123456789"
+}
+
 const nihSSOConfig = {
     group: 'https://federation.nih.gov/person/DLGroups',
     firstName: 'https://federation.nih.gov/person/FirstName',
@@ -681,5 +700,6 @@ module.exports = {
     sites, 
     bagConceptIDs,
     checkDefaultFlags,
-    cleanSurveyData
+    cleanSurveyData,
+    refusalWithdrawalConcepts
 }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -308,7 +308,7 @@ const refusalWithdrawalConcepts = {
     "refusedFutureActivities": "906417725",
     "deceased": "987563196",
 
-    "anyRefusalWithdrawal": "123456789"
+    "anyRefusalWithdrawal": "451953807"
 }
 
 const nihSSOConfig = {

--- a/utils/submission.js
+++ b/utils/submission.js
@@ -212,6 +212,7 @@ const getParticipants = async (req, res, authObj) => {
     else if (req.query.type === 'active') queryType = req.query.type;
     else if (req.query.type === 'notactive') queryType = req.query.type;
     else if (req.query.type === 'passive') queryType = req.query.type;
+    else if (req.query.type === 'refusalswithdrawals') queryType = req.query.type;
     else if (req.query.type === 'individual'){
         if (req.query.token) {
             queryType = "individual";

--- a/utils/submission.js
+++ b/utils/submission.js
@@ -212,7 +212,6 @@ const getParticipants = async (req, res, authObj) => {
     else if (req.query.type === 'active') queryType = req.query.type;
     else if (req.query.type === 'notactive') queryType = req.query.type;
     else if (req.query.type === 'passive') queryType = req.query.type;
-    else if (req.query.type === 'refusalswithdrawals') queryType = req.query.type;
     else if (req.query.type === 'individual'){
         if (req.query.token) {
             queryType = "individual";
@@ -240,6 +239,33 @@ const getParticipants = async (req, res, authObj) => {
         if(result.length > 0) result = removeRestrictedFields(result, restriectedFields, isParent);
         
         return res.status(200).json({data: result, code: 200})
+    }
+    else if (req.query.type === 'refusalswithdrawals') {
+        
+        const { refusalWithdrawalConcepts } = require('./shared');
+
+        let concept;
+
+        if(req.query.option) {
+            if(refusalWithdrawalConcepts[req.query.option]) {
+                concept = refusalWithdrawalConcepts[req.query.option];
+            }
+            else {
+                return res.status(400).json(getResponseJSON('Bad request', 400));
+            }
+        }
+        else {
+            concept = refusalWithdrawalConcepts.anyRefusalWithdrawal;
+        }
+
+        const { retrieveRefusalWithdrawalParticipants } = require('./firestore');
+        let result = await retrieveRefusalWithdrawalParticipants(siteCodes, isParent, concept, limit, page);
+
+        if(result instanceof Error){
+            return res.status(400).json(getResponseJSON(result.message, 400));
+        }
+
+        return res.status(200).json({data: result, code: 200});
     }
     else{
         return res.status(404).json(getResponseJSON('Resource not found', 404));

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -201,8 +201,6 @@ const getToken = async (req, res) => {
 const checkDerivedVariables = async (token, siteCode) => {
     
     const { getParticipantData, getSpecimenCollections, retrieveUserSurveys } = require('./firestore');
-    const { refusalWithdrawalConcepts } = require('./shared');
-
 
     const response = await getParticipantData(token, siteCode);
     const collections = await getSpecimenCollections(token, siteCode);
@@ -320,27 +318,11 @@ const checkDerivedVariables = async (token, siteCode) => {
     }
 
     // anyRefusalWithdrawal
-    if(data['451953807']) {
-        if(data['451953807'] === 104430631) {
-            anyRefusalWithdrawal = (
-                data[refusalWithdrawalConcepts.refusedBaselineBlood] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedBaselineSpecimenSurvey] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedBaselineSaliva] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedrefusedFutureSamplesBaselineBlood] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedFutureSurveys] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedBaselineUrine] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedBaselineSurveys] === 353358909 ||
-                data[refusalWithdrawalConcepts.suspendedContact] === 353358909 ||
-                data[refusalWithdrawalConcepts.withdrewConsent] === 353358909 ||
-                data[refusalWithdrawalConcepts.revokeHIPAA] === 353358909 ||
-                data[refusalWithdrawalConcepts.dataDestroyed] === 353358909 ||
-                data[refusalWithdrawalConcepts.refusedFutureActivities] === 353358909 ||
-                data[refusalWithdrawalConcepts.deceased] === 353358909
-            );
-        }
-    }
-    else {
+    if(typeof data['451953807'] === 'undefined') {
         anyRefusalWithdrawal = true;
+    }
+    else if(data['451953807'] === 104430631) {
+        anyRefusalWithdrawal = checkRefusalWithdrawals(data);
     }
 
 
@@ -448,25 +430,8 @@ const checkDerivedVariables = async (token, siteCode) => {
 
     if(anyRefusalWithdrawal) {
 
-        const refusedBaselineBlood = data[refusalWithdrawalConcepts.refusedBaselineBlood] === 353358909;
-        const refusedBaselineSpecimenSurvey = data[refusalWithdrawalConcepts.refusedBaselineSpecimenSurvey] === 353358909;
-        const refusedBaselineSaliva = data[refusalWithdrawalConcepts.refusedBaselineSaliva] === 353358909;
-        const refusedFutureSamples = data[refusalWithdrawalConcepts.refusedrefusedFutureSamplesBaselineBlood] === 353358909;
-        const refusedFutureSurveys = data[refusalWithdrawalConcepts.refusedFutureSurveys] === 353358909;
-        const refusedBaselineUrine = data[refusalWithdrawalConcepts.refusedBaselineUrine] === 353358909;
-        const refusedBaselineSurveys = data[refusalWithdrawalConcepts.refusedBaselineSurveys] === 353358909;
-        const suspendedContact = data[refusalWithdrawalConcepts.suspendedContact] === 353358909;
-        const withdrewConsent = data[refusalWithdrawalConcepts.withdrewConsent] === 353358909;
-        const revokeHIPAA = data[refusalWithdrawalConcepts.revokeHIPAA] === 353358909;
-        const dataDestroyed = data[refusalWithdrawalConcepts.dataDestroyed] === 353358909;
-        const refusedFutureActivities = data[refusalWithdrawalConcepts.refusedFutureActivities] === 353358909;
-        const deceased = data[refusalWithdrawalConcepts.deceased] === 353358909;
-
         const refusalUpdates = {
-            '451953807':    refusedBaselineBlood || refusedBaselineSpecimenSurvey || refusedBaselineSaliva || refusedFutureSamples ||
-                            refusedFutureSurveys || refusedBaselineUrine || refusedBaselineSurveys || suspendedContact ||
-                            withdrewConsent || revokeHIPAA || dataDestroyed || refusedFutureActivities ||
-                            deceased ? 353358909 : 104430631
+            '451953807': checkRefusalWithdrawals(data) ? 353358909 : 104430631
         }
 
         updates = { ...updates, ...refusalUpdates};
@@ -479,6 +444,27 @@ const checkDerivedVariables = async (token, siteCode) => {
         const { updateParticipantData } = require('./firestore');
         updateParticipantData(doc, updates);
     }
+}
+
+const checkRefusalWithdrawals = (data) => {
+
+    const anyRefusalWithdrawal = (
+        data['685002411']['194410742'] === 353358909 ||
+        data['685002411']['217367618'] === 353358909 ||
+        data['685002411']['277479354'] === 353358909 ||
+        data['685002411']['352996056'] === 353358909 ||
+        data['685002411']['867203506'] === 353358909 ||
+        data['685002411']['949501163'] === 353358909 ||
+        data['685002411']['994064239'] === 353358909 ||
+        data['726389747'] === 353358909 ||
+        data['747006172'] === 353358909 ||
+        data['773707518'] === 353358909 ||
+        data['831041022'] === 353358909 ||
+        data['906417725'] === 353358909 ||
+        data['987563196'] === 353358909
+    ); 
+
+    return anyRefusalWithdrawal;
 }
 
 const validateUsersEmailPhone = async (req, res) => {

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -201,6 +201,8 @@ const getToken = async (req, res) => {
 const checkDerivedVariables = async (token, siteCode) => {
     
     const { getParticipantData, getSpecimenCollections, retrieveUserSurveys } = require('./firestore');
+    const { refusalWithdrawalConcepts } = require('./shared');
+
 
     const response = await getParticipantData(token, siteCode);
     const collections = await getSpecimenCollections(token, siteCode);
@@ -222,6 +224,7 @@ const checkDerivedVariables = async (token, siteCode) => {
     let bloodUrineNotRefused = false;
     let baselineOrderPlaced = false;
     let clinicalSampleDonated = false;
+    let anyRefusalWithdrawal = false;
 
     // incentiveEligible
     if(data['130371375']['266600170']['731498909'] === 104430631) {
@@ -314,6 +317,30 @@ const checkDerivedVariables = async (token, siteCode) => {
         else {
             clinicalSampleDonated = true;
         }
+    }
+
+    // anyRefusalWithdrawal
+    if(data['451953807']) {
+        if(data['451953807'] === 104430631) {
+            anyRefusalWithdrawal = (
+                data[refusalWithdrawalConcepts.refusedBaselineBlood] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedBaselineSpecimenSurvey] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedBaselineSaliva] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedrefusedFutureSamplesBaselineBlood] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedFutureSurveys] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedBaselineUrine] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedBaselineSurveys] === 353358909 ||
+                data[refusalWithdrawalConcepts.suspendedContact] === 353358909 ||
+                data[refusalWithdrawalConcepts.withdrewConsent] === 353358909 ||
+                data[refusalWithdrawalConcepts.revokeHIPAA] === 353358909 ||
+                data[refusalWithdrawalConcepts.dataDestroyed] === 353358909 ||
+                data[refusalWithdrawalConcepts.refusedFutureActivities] === 353358909 ||
+                data[refusalWithdrawalConcepts.deceased] === 353358909
+            );
+        }
+    }
+    else {
+        anyRefusalWithdrawal = true;
     }
 
 
@@ -417,6 +444,32 @@ const checkDerivedVariables = async (token, siteCode) => {
         }
 
         updates = { ...updates, ...sampleUpdates};
+    }
+
+    if(anyRefusalWithdrawal) {
+
+        const refusedBaselineBlood = data[refusalWithdrawalConcepts.refusedBaselineBlood] === 353358909;
+        const refusedBaselineSpecimenSurvey = data[refusalWithdrawalConcepts.refusedBaselineSpecimenSurvey] === 353358909;
+        const refusedBaselineSaliva = data[refusalWithdrawalConcepts.refusedBaselineSaliva] === 353358909;
+        const refusedFutureSamples = data[refusalWithdrawalConcepts.refusedrefusedFutureSamplesBaselineBlood] === 353358909;
+        const refusedFutureSurveys = data[refusalWithdrawalConcepts.refusedFutureSurveys] === 353358909;
+        const refusedBaselineUrine = data[refusalWithdrawalConcepts.refusedBaselineUrine] === 353358909;
+        const refusedBaselineSurveys = data[refusalWithdrawalConcepts.refusedBaselineSurveys] === 353358909;
+        const suspendedContact = data[refusalWithdrawalConcepts.suspendedContact] === 353358909;
+        const withdrewConsent = data[refusalWithdrawalConcepts.withdrewConsent] === 353358909;
+        const revokeHIPAA = data[refusalWithdrawalConcepts.revokeHIPAA] === 353358909;
+        const dataDestroyed = data[refusalWithdrawalConcepts.dataDestroyed] === 353358909;
+        const refusedFutureActivities = data[refusalWithdrawalConcepts.refusedFutureActivities] === 353358909;
+        const deceased = data[refusalWithdrawalConcepts.deceased] === 353358909;
+
+        const refusalUpdates = {
+            '451953807':    refusedBaselineBlood || refusedBaselineSpecimenSurvey || refusedBaselineSaliva || refusedFutureSamples ||
+                            refusedFutureSurveys || refusedBaselineUrine || refusedBaselineSurveys || suspendedContact ||
+                            withdrewConsent || revokeHIPAA || dataDestroyed || refusedFutureActivities ||
+                            deceased ? 353358909 : 104430631
+        }
+
+        updates = { ...updates, ...refusalUpdates};
     }
 
     console.log("UPDATES");


### PR DESCRIPTION
This PR is to fix issue https://github.com/episphere/connect/issues/604

* Added condition in `getParticipants` to retrieve participants based on either a default search criteria or one that can be passed into the API as an option
* New condition utilizes new shared constant `refusalWithdrawalConcepts` that defines the option names and corresponding Concept ID
* New condition utilizes new Firestore function `retrieveRefusalWithdrawalParticipants` that builds and runs the query to retrieve the appropriate participant data
* Added logic to `checkDerivedVariables` to calculate new derived variable `anyRefusalWithdrawal` (Concept ID 451953807) which is used as a default option for new `getParticipants` functionality
* Added function `checkRefusalWithdrawals` to calculate value of `anyRefusalWithdrawal` (Concept ID 451953807)

NOTE: New indexes were required to be added in Firebase for each search option