### PR TITLE
Add Response Parameters to Refusal / Withdrawal API

### DIFF
--- a/utils/submission.js
+++ b/utils/submission.js
@@ -265,7 +265,7 @@ const getParticipants = async (req, res, authObj) => {
             return res.status(400).json(getResponseJSON(result.message, 400));
         }
 
-        return res.status(200).json({data: result, code: 200});
+        return res.status(200).json({data: result, code: 200, limit, dataSize: result.length});
     }
     else{
         return res.status(404).json(getResponseJSON('Resource not found', 404));


### PR DESCRIPTION
This PR is a small update to PR https://github.com/episphere/connectFaas/pull/321

* Adding `limit` and `dataSize` parameters to response object of `refusalswithdrawals` type within `getParticipants` API in order to match the structure of other types within the same API