### PR TITLE
SiteManager Dashboard: Fix phone to email magic link

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1931,7 +1931,6 @@ const updateUserEmailSigninMethod = async (email, uid) => {
     newEmail = newEmail.toString().trim();
     try {
         await admin.auth().updateUser(uid, {
-            password: "password",
             providerToLink: {
             email: newEmail,
             uid: newEmail,


### PR DESCRIPTION
This PR addresses following issue:
_"On switch from phone to email and upon signin. It doesnt give you magic link but asks user for password."_

Related PR:
https://github.com/episphere/connectFaas/pull/341
https://github.com/episphere/connectFaas/pull/346

Related issue: episphere/dashboard#493