### PR TITLE
Enabling Array Payloads - Update Participant Data API

### DIFF
--- a/updateParticipantData.json
+++ b/updateParticipantData.json
@@ -394,5 +394,13 @@
 		"values": [104430631, 353358909],
 		"dataType": "number",
 		"mustExist": false
+	},
+	"173836415.266600170.543608829": {
+		"dataType": "array",
+		"mustExist": false
+	},
+	"173836415.266600170.110349197": {
+		"dataType": "array",
+		"mustExist": false
 	}
 }

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -245,7 +245,7 @@ const updateParticipantData = async (req, res, authObj) => {
         
             if(primaryIdentifiers.indexOf(key) !== -1) continue;
 
-            if(typeof(dataObj[key]) === 'object') flat(dataObj[key], 'newData', key);
+            if(typeof(dataObj[key]) === 'object' && !Array.isArray(dataObj[key])) flat(dataObj[key], 'newData', key);
             else flattened['newData'][key] = dataObj[key];
 
             updatedData = {...updatedData, ...flattened.newData}
@@ -320,6 +320,19 @@ const qc = (newData, existingData, rules) => {
             if(rules[key].dataType) {
                 if(rules[key].dataType == 'ISO') {
                     if(typeof newData[key] !== "string" || !(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(newData[key]))) {
+                        errors.push(" Invalid data type / format for Key (" + key + ")");
+                    }
+                }
+                else if(rules[key].dataType == 'array') {
+                    if(Array.isArray(newData[key])) {
+                        for(const element of newData[key]) {
+                            if(typeof element !== 'string') {
+                                errors.push(" Invalid data type / format in array element for Key (" + key + ")");
+                                break;
+                            }
+                        }
+                    }
+                    else {
                         errors.push(" Invalid data type / format for Key (" + key + ")");
                     }
                 }

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -318,12 +318,12 @@ const qc = (newData, existingData, rules) => {
             }
 
             if(rules[key].dataType) {
-                if(rules[key].dataType == 'ISO') {
+                if(rules[key].dataType === 'ISO') {
                     if(typeof newData[key] !== "string" || !(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(newData[key]))) {
                         errors.push(" Invalid data type / format for Key (" + key + ")");
                     }
                 }
-                else if(rules[key].dataType == 'array') {
+                else if(rules[key].dataType === 'array') {
                     if(Array.isArray(newData[key])) {
                         for(const element of newData[key]) {
                             if(typeof element !== 'string') {


### PR DESCRIPTION
This PR resolves issue https://github.com/episphere/connect/issues/639

* Add new keys to `updateParticipantData.json`
* Add rules to `qc()` to allow value types of `array` to be accepted
* Arrays must contain only string objects
* Preventing flattening of keys with values of type `array` when flattening new data