### PR TITLE
add updateParticipantDataNotSite to dashboard.js

### DIFF
--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -72,6 +72,19 @@ const dashboard = async (req, res) => {
         const { updateParticipantData } = require('./sites');
         return await updateParticipantData(req, res, authObj);
     }
+    else if (api === 'updateParticipantDataNotSite') {
+        if(req.method !== 'POST') {
+            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+        }   
+        const {submit} = require('./submission');
+        let body = req.body;
+        if(!body.uid) {
+            return res.status(500).json(getResponseJSON('Missing UID!', 405));
+        }
+        let uid = body.uid;
+        delete body['uid']
+        return submit(res, body, uid)
+    }
     else if (api === 'updateUserAuthentication') {
         const { updateUserAuthentication } = require('./sites');
         return await updateUserAuthentication(req, res, authObj);


### PR DESCRIPTION
Add `updateParticipantDataNotSite()` to `dashboard.js`

This step is connected to [issue #635 ](https://github.com/episphere/connect/issues/635) to allow editing of user data by a logged-in user in SMDB. This will allow calling the `updateParticipantDataNotSite` endpoint from SMDB, which, in turn, processes the new data submission.