### PR TITLE
BPTL Dashboard: Enable collection search across all sites for BPTL users

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -215,7 +215,8 @@ const biospecimenAPIs = async (req, res) => {
             const masterSpecimenId = req.query.masterSpecimenId;
             if(!masterSpecimenId) return res.status(400).json(getResponseJSON('Bad request!', 400));
             const { searchSpecimen } = require('./firestore');
-            const response = await searchSpecimen(masterSpecimenId, siteCode);
+            const allSitesFlag = (req.query.allSitesFlag) ? true : false
+            const response = await searchSpecimen(masterSpecimenId, siteCode, allSitesFlag);
             if(!response) return res.status(404).json(getResponseJSON('Data not found!', 404));
             return res.status(200).json({data: response, code:200});
         }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -789,8 +789,7 @@ const filterDB = async (queries, siteCode, isParent) => {
             if(key === 'token') query = query.where('token', '==', queries[key]);
             if(key === 'studyId') query = query.where('state.studyId', '==', queries[key]);
         }
-        let snapshot = ``
-        queries['allSiteSearch'] === 'true' ? snapshot = await query.get() : snapshot = await query.where('827220437', operator, siteCode).get();
+        const snapshot = await (queries['allSiteSearch'] === 'true' ? query.get() : query.where('827220437', operator, siteCode).get());
         if(snapshot.size !== 0){
             return snapshot.docs.map(document => document.data());
         }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -789,7 +789,9 @@ const filterDB = async (queries, siteCode, isParent) => {
             if(key === 'token') query = query.where('token', '==', queries[key]);
             if(key === 'studyId') query = query.where('state.studyId', '==', queries[key]);
         }
-        const snapshot = await query.where('827220437', operator, siteCode).get();
+        let snapshot = ``
+        queries['allSiteSearch'] === 'true' ? snapshot = await query.get() : snapshot = await query.where('827220437', operator, siteCode).get();
+        const snapshot = await query.where('827220437', 'in', siteCodes).get();
         if(snapshot.size !== 0){
             return snapshot.docs.map(document => document.data());
         }
@@ -999,13 +1001,14 @@ const reportMissingSpecimen = async (siteAcronym, requestData) => {
 
 }
 
-const searchSpecimen = async (masterSpecimenId, siteCode) => {
+const searchSpecimen = async (masterSpecimenId, siteCode, allSitesFlag) => {
     const snapshot = await db.collection('biospecimen').where('820476880', '==', masterSpecimenId).get();
-    if(snapshot.size === 1) {
+    if (snapshot.size === 1) {
         const token = snapshot.docs[0].data().token;
         const response = await db.collection('participants').where('token', '==', token).get();
         const participantSiteCode = response.docs[0].data()['827220437'];
-        if(participantSiteCode === siteCode) return snapshot.docs[0].data();
+        if (allSitesFlag) return snapshot.docs[0].data();
+        else if (!allSitesFlag && participantSiteCode === siteCode) return snapshot.docs[0].data();
         else return false;
     }
     else return false;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -791,7 +791,6 @@ const filterDB = async (queries, siteCode, isParent) => {
         }
         let snapshot = ``
         queries['allSiteSearch'] === 'true' ? snapshot = await query.get() : snapshot = await query.where('827220437', operator, siteCode).get();
-        const snapshot = await query.where('827220437', operator, siteCodes).get();
         if(snapshot.size !== 0){
             return snapshot.docs.map(document => document.data());
         }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -791,7 +791,7 @@ const filterDB = async (queries, siteCode, isParent) => {
         }
         let snapshot = ``
         queries['allSiteSearch'] === 'true' ? snapshot = await query.get() : snapshot = await query.where('827220437', operator, siteCode).get();
-        const snapshot = await query.where('827220437', 'in', siteCodes).get();
+        const snapshot = await query.where('827220437', operator, siteCodes).get();
         if(snapshot.size !== 0){
             return snapshot.docs.map(document => document.data());
         }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1002,11 +1002,11 @@ const reportMissingSpecimen = async (siteAcronym, requestData) => {
 const searchSpecimen = async (masterSpecimenId, siteCode, allSitesFlag) => {
     const snapshot = await db.collection('biospecimen').where('820476880', '==', masterSpecimenId).get();
     if (snapshot.size === 1) {
+        if (allSitesFlag) return snapshot.docs[0].data();
         const token = snapshot.docs[0].data().token;
         const response = await db.collection('participants').where('token', '==', token).get();
-        const participantSiteCode = response.docs[0].data()['827220437'];
-        if (allSitesFlag) return snapshot.docs[0].data();
-        else if (!allSitesFlag && participantSiteCode === siteCode) return snapshot.docs[0].data();
+        const participantSiteCode = response.docs[0].data()['827220437']; 
+        if (participantSiteCode === siteCode) return snapshot.docs[0].data();
         else return false;
     }
     else return false;


### PR DESCRIPTION
This PR addresses following issue https://github.com/episphere/biospecimen/issues/426:
Originally users could lookup only NIH specimens. Moving forward BPTL users can
search for specimens using collection ID from different sites.

Related PR: https://github.com/episphere/biospecimen/pull/536