### PR TITLE
Bug Fix - Participant data cleanup remove stub records

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -417,7 +417,7 @@ const removeParticipantsDataDestruction = async () => {
     try {
         let count = 0;
         const millisecondsInTwoDays = 2 * 24 * 60 * 60 * 1000;
-        const dataDestructionFieldList = ['104278817', '119449326', '153713899', '173836415', '231676651', '262613359', '268665918', '269050420', '304438543', '359404406', '399159511', '407743866', '412000022', '471168198', '479278368', '524352591', '526455436', '544150384', '558435199', '577794331', '592227431', '613641698', '664453818', '744604255', '747006172', '765336427', '773707518', '826240317', '831041022', '883668444', '996038075', 'token', 'Connect_ID', 'query', 'pin'];
+        const stubRecordList = ['104278817', '119449326', '153713899', '173836415', '231676651', '262613359', '268665918', '269050420', '304438543', '359404406', '399159511', '407743866', '412000022', '471168198', '479278368', '524352591', '526455436', '544150384', '558435199', '577794331', '592227431', '613641698', '664453818', '744604255', '747006172', '765336427', '773707518', '826240317', '831041022', '883668444', '996038075', 'token', 'Connect_ID', 'query', 'pin', 'state', '371067537', '827220437'];
         const destroyDataCId = fieldMapping.participantMap.destroyData.toString();
         const dateRequestedDataDestroyCId = fieldMapping.participantMap.dateRequestedDataDestroy.toString();
         const destroyDataCategoricalCId = fieldMapping.participantMap.destroyDataCategorical.toString();
@@ -440,7 +440,7 @@ const removeParticipantsDataDestruction = async () => {
                 const fieldKeys = Object.keys(participant)
                 const participantRef = doc.ref;
                 fieldKeys.forEach(key => {
-                    if (!dataDestructionFieldList.includes(key)) {
+                    if (!stubRecordList.includes(key)) {
                         batch.update(participantRef, { [key]: admin.firestore.FieldValue.delete() });
                     }
                 })


### PR DESCRIPTION
This PR adresses a issue that SMDB can not look up participant who removed data destruction

- Renamed variable `dataDestructionFieldList` to `stubRecordList`
- Added `state` `371067537`  `827220437` into `stubRecordList`

