### PR TITLE
fix updateParticipantFirebaseAuth location

### DIFF
--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -1,8 +1,7 @@
 const { getResponseJSON, setHeadersDomainRestricted } = require('./shared');
 const { recruitSubmit, getUserProfile, getUserSurveys, getUserCollections } = require('./submission');
 const { retrieveNotifications } = require('./notifications');
-const { validateToken, generateToken, validateUsersEmailPhone } = require('./validation');
-const { updateParticipantFirebaseAuthentication } = require('./firestore');
+const { validateToken, generateToken, updateParticipantFirebaseAuthentication, validateUsersEmailPhone } = require('./validation');
 
 const connectApp = async (req, res) => {
     setHeadersDomainRestricted(req, res);

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1888,39 +1888,6 @@ const verifyUsersEmailOrPhone = async (req) => {
     }
 }
 
-const updateParticipantFirebaseAuthentication = async (req, res) => {
-    if(req.method !== 'POST') {
-        return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
-    }
-    const data = req.body.data;
-    const flag = data.flag;
-    const uid =  data.uid;
-
-    if(data === undefined) {
-        return res.status(400).json(getResponseJSON('Bad request. Data is not defined in request body.', 400));
-    }
-
-    let status = '';
-    if (flag === `replaceSignin`) {
-        if (data['phone']) {
-            status = await updateUserPhoneSigninMethod(data.phone, uid);
-        } else if (data['email'] && flag === `replaceSignin`) {
-            status = await updateUserEmailSigninMethod(data.email, uid);
-        }
-    }
-
-    if (flag === `updateEmail` || flag === `updatePhone`) {
-        status = await updateUsersCurrentLogin(data, uid);
-    }
-
-    if (status === true) return res.status(200).json({code: 200});
-    else if (status === `auth/phone-number-already-exists`) return res.status(409).json(getResponseJSON('The user with provided phone number already exists.', 409));
-    else if (status === `auth/email-already-exists`) return res.status(409).json(getResponseJSON('The user with the provided email already exists.', 409));
-    else if (status === `auth/invalid-phone-number`) return res.status(403).json(getResponseJSON('Invalid Phone number', 403));
-    else if (status === `auth/invalid-email`) return res.status(403).json(getResponseJSON('Invalid Email', 403));
-    else return res.status(400).json(getResponseJSON('Operation Unsuccessful', 400));
-}
-
 const updateUsersCurrentLogin = async (req, uid) => {   
     const queries = req
     if (queries.email) {
@@ -2094,5 +2061,4 @@ module.exports = {
     updateUserPhoneSigninMethod,
     updateUserEmailSigninMethod,
     updateUsersCurrentLogin,
-    updateParticipantFirebaseAuthentication
 }

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -488,6 +488,36 @@ const validateUsersEmailPhone = async (req, res) => {
     else return res.status(200).json({data: {accountExists: false}, code: 200})
 }
 
+const updateParticipantFirebaseAuthentication = async (req, res) => {
+    if(req.method !== 'POST') {
+        return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+    }
+    const data = req.body.data;
+    const flag = data.flag;
+    const uid =  data.uid;
+
+    if(data === undefined) {
+        return res.status(400).json(getResponseJSON('Bad request. Data is not defined in request body.', 400));
+    }
+
+    let status = '';
+    const { updateUserPhoneSigninMethod, updateUserEmailSigninMethod, updateUsersCurrentLogin } = require('./firestore');
+    if (flag === `replaceSignin`) {
+        if (data['phone']) status = await updateUserPhoneSigninMethod(data.phone, uid);
+        else if (data['email']) status = await updateUserEmailSigninMethod(data.email, uid);
+        else return res.status(403).json(getResponseJSON('Invalid Request. Phone or email data not defined in request.', 403));
+    }
+
+    if (flag === `updateEmail` || flag === `updatePhone`) status = await updateUsersCurrentLogin(data, uid);
+
+    if (status === true) return res.status(200).json({code: 200});
+    else if (status === `auth/phone-number-already-exists`) return res.status(409).json(getResponseJSON('The user with provided phone number already exists.', 409));
+    else if (status === `auth/email-already-exists`) return res.status(409).json(getResponseJSON('The user with the provided email already exists.', 409));
+    else if (status === `auth/invalid-phone-number`) return res.status(403).json(getResponseJSON('Invalid Phone number', 403));
+    else if (status === `auth/invalid-email`) return res.status(403).json(getResponseJSON('Invalid Email', 403));
+    else return res.status(400).json(getResponseJSON('Operation Unsuccessful', 400));
+}
+
 const isIsoDate = (str) => {
     if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) return false;
     const d = new Date(str);
@@ -501,5 +531,6 @@ module.exports = {
     getToken,
     checkDerivedVariables,
     validateUsersEmailPhone,
+    updateParticipantFirebaseAuthentication,
     isIsoDate
 }


### PR DESCRIPTION
This PR addresses a fix to https://github.com/episphere/connectFaas/pull/361

`updateParticipantFirebaseAuthentication()` was calling `getResponseJSON()`, which wasn’t imported.

(1) moved updateParticipantFirebaseAuthentication() from `firestore.js` to `validation.js`: better architectural move, per Warren’s suggestion.
(2) current location `validation.js` imports `getResponseJSON`.
(3) added: `const { updateUserPhoneSigninMethod, updateUserEmailSigninMethod, updateUsersCurrentLogin } = require('./firestore'); for ref to execution functions in firestore.js`