### PR TITLE
Implement duplicate account label check

### DIFF
--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -32,9 +32,9 @@ const connectApp = async (req, res) => {
     
     const api = query.api;
 
-    console.log(api);
-    console.log(uid);
+    console.log(`PWA API: ${api}, called from uid: ${uid}`);
 
+  try {
     if (api === 'submit') return recruitSubmit(req, res, uid);
 
     else if (api === 'getUserProfile') return getUserProfile(req, res, uid);
@@ -54,6 +54,11 @@ const connectApp = async (req, res) => {
     else if (api === 'validateEmailOrPhone') return validateUsersEmailPhone(req, res);
 
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
+
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json(getResponseJSON(error.message, 500));
+  }
 }
 
 module.exports = {

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -18,6 +18,13 @@ module.exports = {
     healthCareProvider: 827220437,
     reportMissingTube: 258745303,
     submitShipmentFlag: 145971562,
+    pinMatch: 948195369,
+    verificationStatus: 821247024,
+    notVerified: 875007964,
+    verified: 197316935, 
+    duplicate: 922622075,
+    cannotBeVerified: 219863910,
+    outreachTimeOut: 160161595,
 
     tubesBagsCids: {
         serumSeparatorTube1: 299553921,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -17,40 +17,50 @@ const nciConceptId = `517700004`;
 const tubesBagsCids = fieldMapping.tubesBagsCids;
 
 const verifyToken = async (token) => {
-    try{
-        const response = await db.collection('participants').where('token', '==', token).get();
-        if(response.size === 1) {
-            if(response.docs[0].data().state.uid === undefined){
-                return response.docs[0].id;
-            }else{
-                return false;
-            }
-        }
-        return false;
+  const resultObj = { isDuplicateAccount: false, isValidToken: false, docId: null };
+  const snapshot = await db
+    .collection('participants')
+    .where('token', '==', token)
+    .get();
+
+  if (snapshot.size === 1) {
+    const participantData = snapshot.docs[0].data();
+    if (participantData[fieldMapping.verificationStatus] === fieldMapping.duplicate) {
+      resultObj.isDuplicateAccount = true;
+      return resultObj;
     }
-    catch(error){
-        console.error(error);
-        return new Error(error);
+
+    if (participantData.state.uid === undefined) {
+      resultObj.isValidToken = true;
+      resultObj.docId = snapshot.docs[0].id;
     }
-}
+  }
+
+  return resultObj;
+};
 
 const verifyPin = async (pin) => {
-    try{
-        const response = await db.collection('participants').where('pin', '==', pin).get();
-        if(response.size === 1) {
-            if(response.docs[0].data().state.uid === undefined){
-                return response.docs[0].id;
-            }else{
-                return false;
-            }
-        }
-        return false;
+  const resultObj = { isDuplicateAccount: false, isValidPin: false, docId: null };
+  const snapshot = await db
+    .collection('participants')
+    .where('pin', '==', pin)
+    .get();
+
+  if (snapshot.size === 1) {
+    const participantData = snapshot.docs[0].data();
+    if (participantData[fieldMapping.verificationStatus] === fieldMapping.duplicate) {
+      resultObj.isDuplicateAccount = true;
+      return resultObj;
     }
-    catch(error){
-        console.error(error);
-        return new Error(error);
+    
+    if (participantData.state.uid === undefined) {
+      resultObj.isValidPin = true;
+      resultObj.docId = snapshot.docs[0].id;
     }
-}
+  }
+
+  return resultObj;
+};
 
 const validateIDToken = async (idToken) => {
     try{

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -47,14 +47,6 @@ const verifyTokenOrPin = async ({ token = null, pin = null }) => {
   return resultObj;
 };
 
-const verifyToken = async (token) => {
-  return await verifyTokenOrPin({ token });
-};
-
-const verifyPin = async (pin) => {
-  return await verifyTokenOrPin({ pin });
-};
-
 const validateIDToken = async (idToken) => {
     try{
         const decodedToken = await admin.auth().verifyIdToken(idToken, true);
@@ -1977,8 +1969,7 @@ module.exports = {
     createRecord,
     recordExists,
     validateIDToken,
-    verifyToken,
-    verifyPin,
+    verifyTokenOrPin,
     linkParticipanttoFirebaseUID,
     participantExists,
     sanityCheckConnectID,

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -57,7 +57,7 @@ const validateToken = async (req, res, uid) => {
         verifyToken,
         linkParticipanttoFirebaseUID,
       } = require('./firestore');
-      const { isDuplicateAccount, isValidToken, docId } = await verifyToken(token);
+      const { isDuplicateAccount, isValid: isValidToken, docId } = await verifyToken(token);
       if (isDuplicateAccount) {
         return res.status(202).json(getResponseJSON('Duplicate account', 202));
       }
@@ -76,7 +76,7 @@ const validateToken = async (req, res, uid) => {
         linkParticipanttoFirebaseUID,
         updateResponse,
       } = require('./firestore');
-      const { isDuplicateAccount, isValidPin, docId } = await verifyPin(pin);
+      const { isDuplicateAccount, isValid: isValidPin, docId } = await verifyPin(pin);
       if (isDuplicateAccount) {
         return res.status(202).json(getResponseJSON('Duplicate account', 202));
       }

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -54,10 +54,16 @@ const validateToken = async (req, res, uid) => {
 
     if (token) {
       const {
-        verifyToken,
+        verifyTokenOrPin,
         linkParticipanttoFirebaseUID,
       } = require('./firestore');
-      const { isDuplicateAccount, isValid: isValidToken, docId } = await verifyToken(token);
+
+      const {
+        isDuplicateAccount,
+        isValid: isValidToken,
+        docId,
+      } = await verifyTokenOrPin({ token });
+
       if (isDuplicateAccount) {
         return res.status(202).json(getResponseJSON('Duplicate account', 202));
       }
@@ -72,11 +78,17 @@ const validateToken = async (req, res, uid) => {
 
     if (pin) {
       const {
-        verifyPin,
+        verifyTokenOrPin,
         linkParticipanttoFirebaseUID,
         updateResponse,
       } = require('./firestore');
-      const { isDuplicateAccount, isValid: isValidPin, docId } = await verifyPin(pin);
+
+      const {
+        isDuplicateAccount,
+        isValid: isValidPin,
+        docId,
+      } = await verifyTokenOrPin({ pin });
+
       if (isDuplicateAccount) {
         return res.status(202).json(getResponseJSON('Duplicate account', 202));
       }


### PR DESCRIPTION
This PR implements backend code for issue [#659](https://github.com/episphere/connect/issues/659), with some code cleanup. Below are details:
- Moved error handling to API level, for code simplicity
- Added duplicate flag check when verifying token and pin
- Moved common logic for token and pin checks to `verifyTokenOrPin`, to eliminate repeated code, based on comment from Abhinav
- Retired `verifyToken` and `verifyPin` functions, based on comment from Tony