### PR TITLE
handle name search case sensitivity

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -811,13 +811,13 @@ const filterDB = async (queries, siteCode, isParent) => {
         for (let key in queryKeys) {
             if (key === 'firstName' || key === 'lastName') {
                 const path = `query.${key}`;
-                const queryValue =(key === 'firstName' ? queries.firstName : queries.lastName).toLowerCase();
+                const queryValue = key === 'firstName' ? queries.firstName : queries.lastName;
                 const operation = (nameType === 'string') ? '==' : 'array-contains';
                 participantQuery = participantQuery.where(path, operation, queryValue);
             }
             if (key === 'email' || key === 'phone') {
                 const path = `query.${key === 'email' ? 'allEmails' : 'allPhoneNo'}`;
-                const queryValue = (key === 'email' ? queries.email : queries.phone).toLowerCase();
+                const queryValue = key === 'email' ? queries.email : queries.phone;
                 participantQuery = participantQuery.where(path, 'array-contains', queryValue);
             }
             if (key === 'dob') participantQuery = participantQuery.where('371067537', '==', queries.dob);
@@ -879,6 +879,10 @@ const filterDB = async (queries, siteCode, isParent) => {
     // If neither firstName nor lastName are in the query, run a simple query that doesn't need post-processing. This is the else statement, return early.
     const collection = db.collection('participants');
     let fetchedResults = [];
+
+    if (queries.firstName) queries.firstName = queries.firstName.toLowerCase();
+    if (queries.lastName) queries.lastName = queries.lastName.toLowerCase();
+    if (queries.email) queries.email = queries.email.toLowerCase();
         
     try {
         if (queries.firstName && queries.lastName && (queries.email || queries.phone)) {


### PR DESCRIPTION
PR: Handle name search case sensitivity.

This is a small update to:
https://github.com/episphere/connectFaas/pull/381
It is in continued support of:
https://github.com/episphere/connect/issues/654

Issue: the query names were being forced to lowercase (desired behavior), but the results filter was filtering based on the original query. This caused lowercase searches to succeed and searches with uppercase characters to fail.

Update: Check for firstName, lastName, and email at the beginning of function execution and convert any/all to lowercase. This improves upon converting the query string to lowercase and then converting the filter to lowercase.