### PR TITLE
BPTL Dashboard: Added mutex to prevent race condition in Package Receipt

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1894,20 +1894,21 @@ const setPackageReceiptFedex = async (data) => {
 */ 
 
 let mutex = Promise.resolve(); // assign mutex globally to reuse same version of mutex for multiple calls to processReceiptData()
+
 const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTimeStamp) => {
     for (let key in collectionIdHolder) {
-            try {
-                const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', collectionIdHolder[key]).get(); // find related biospecimen using collection id change this
-                const docId = secondSnapshot.docs[0].id; // grab the docID to update the biospecimen
-                for (const element of collectionIdKeys[key]['234868461']) {
-                        const tubeId = element.split(' ')[1];
-                        const conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
-                        const conceptIdTubes = `${conceptTube}.926457119`
-                        mutex = mutex.then(() => { // reassign mutex to syncronize the next execution of the promise
-                            return db.collection("biospecimen").doc(docId).update({ 
-                                                                "926457119": dateTimeStamp, 
-                                                                [conceptIdTubes] : dateTimeStamp }) // using the docids update the biospecimen with the received date
-                        })
+        try {
+            const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', collectionIdHolder[key]).get(); // find related biospecimen using collection id change this
+            const docId = secondSnapshot.docs[0].id; // grab the docID to update the biospecimen
+            for (const element of collectionIdKeys[key]['234868461']) {
+                const tubeId = element.split(' ')[1];
+                const conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
+                const conceptIdTubes = `${conceptTube}.926457119`
+                mutex = mutex.then(() => { // reassign mutex to syncronize the next execution of the promise
+                    return db.collection("biospecimen").doc(docId).update({ 
+                                                        "926457119": dateTimeStamp, 
+                                                        [conceptIdTubes] : dateTimeStamp }) // using the docids update the biospecimen with the received date
+                })
             }
         }
         catch(error){

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1888,8 +1888,9 @@ const setPackageReceiptFedex = async (data) => {
     }
 }
 
+// mutex implementation source: www.nodejsdesignpatterns.com/blog/node-js-race-conditions/
+let mutex = Promise.resolve(); // assign mutex globally to reuse same version of mutex for multiple calls to processReceiptData()
 const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTimeStamp) => {
-    let mutex = Promise.resolve();
     for (let key in collectionIdHolder) {
             try {
                 const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', collectionIdHolder[key]).get(); // find related biospecimen using collection id change this
@@ -1898,7 +1899,7 @@ const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTime
                         const tubeId = element.split(' ')[1];
                         const conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
                         const conceptIdTubes = `${conceptTube}.926457119`
-                        mutex.then(() => {
+                        mutex = mutex.then(() => { // reassign mutex to syncronize the next execution of the promise
                             return db.collection("biospecimen").doc(docId).update({ 
                                                                 "926457119": dateTimeStamp, 
                                                                 [conceptIdTubes] : dateTimeStamp }) // using the docids update the biospecimen with the received date

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1895,9 +1895,9 @@ const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTime
                 const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', collectionIdHolder[key]).get(); // find related biospecimen using collection id change this
                 const docId = secondSnapshot.docs[0].id; // grab the docID to update the biospecimen
                 for (const element of collectionIdKeys[key]['234868461']) {
-                        let tubeId = element.split(' ')[1];
-                        let conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
-                        let conceptIdTubes = `${conceptTube}.926457119`
+                        const tubeId = element.split(' ')[1];
+                        const conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
+                        const conceptIdTubes = `${conceptTube}.926457119`
                         mutex.then(() => {
                             return db.collection("biospecimen").doc(docId).update({ 
                                                                 "926457119": dateTimeStamp, 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1888,8 +1888,12 @@ const setPackageReceiptFedex = async (data) => {
     }
 }
 
-// mutex implementation source: www.nodejsdesignpatterns.com/blog/node-js-race-conditions/
-// Using mutex so that concurrent calls to processReceiptData() can be queued to be executed sequentially.
+/**
+ * mutex implementation source: www.nodejsdesignpatterns.com/blog/node-js-race-conditions/
+   Using  mutex allows us to have concurrent calls to processReceiptData() & are queued to be executed sequentially.
+*/ 
+
+let mutex = Promise.resolve(); // assign mutex globally to reuse same version of mutex for multiple calls to processReceiptData()
 const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTimeStamp) => {
     for (let key in collectionIdHolder) {
             try {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1889,25 +1889,27 @@ const setPackageReceiptFedex = async (data) => {
 }
 
 const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTimeStamp) => {
+    let mutex = Promise.resolve();
     for (let key in collectionIdHolder) {
-        if (collectionIdHolder.hasOwnProperty(key)) {
             try {
                 const secondSnapshot = await db.collection("biospecimen").where('820476880', '==', collectionIdHolder[key]).get(); // find related biospecimen using collection id change this
                 const docId = secondSnapshot.docs[0].id; // grab the docID to update the biospecimen
                 for (const element of collectionIdKeys[key]['234868461']) {
-                    let tubeId = element.split(' ')[1];
-                    let conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
-                    let conceptIdTubes = `${conceptTube}.926457119`
-                    await db.collection("biospecimen").doc(docId).update({ 
-                                                        "926457119": dateTimeStamp, 
-                                                        [conceptIdTubes] : dateTimeStamp }) // using the docids update the biospecimen with the received date
+                        let tubeId = element.split(' ')[1];
+                        let conceptTube = collectionIdConversion[tubeId]; // grab tube ids & map them to appropriate concept ids
+                        let conceptIdTubes = `${conceptTube}.926457119`
+                        mutex.then(() => {
+                            return db.collection("biospecimen").doc(docId).update({ 
+                                                                "926457119": dateTimeStamp, 
+                                                                [conceptIdTubes] : dateTimeStamp }) // using the docids update the biospecimen with the received date
+                        })
             }
         }
         catch(error){
             return new Error(error);
-        }
         }}
-    }
+}
+
 const kitStatusCounterVariation = async (currentkitStatus, prevKitStatus) => {
     try {
         await db.collection("bptlMetrics").doc('--metrics--').update({ 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1889,7 +1889,7 @@ const setPackageReceiptFedex = async (data) => {
 }
 
 // mutex implementation source: www.nodejsdesignpatterns.com/blog/node-js-race-conditions/
-let mutex = Promise.resolve(); // assign mutex globally to reuse same version of mutex for multiple calls to processReceiptData()
+// Using mutex so that concurrent calls to processReceiptData() can be queued to be executed sequentially.
 const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTimeStamp) => {
     for (let key in collectionIdHolder) {
             try {


### PR DESCRIPTION
https://github.com/episphere/connect/issues/676

As the title suggests, multiple concurrent calls to `processReceiptData()` have led to data inconsistencies when performing writes/updates. To prevent race conditions in a simpler way, we can initialize mutex as an instance of a resolved promise.

The goal here is that every time the function `processReceiptData()` is invoked, we are effectively "queueing" the execution of the code. For the first call, our initial instance of the mutex promise is a resolved promise, so the code will be executed straight away on the next cycle of the event loop.

Calling .then() on a promise returns a new promise instance that is used to replace the original mutex instance. This new promise instance is also returned by the `processReceiptData() `function.

This allows us to have concurrent calls to `processReceiptData() `being queued to be executed sequentially.

**Performance**: 
Based on below test cases, the code with mutex performs significantly better than the code without mutex in both test cases. This suggests that the use of a mutex  is beneficial for performance improvement. It can handle concurrency and prevent race conditions when processing, updating shared data & performing firestore writes/updates.

Sources
[www.nodejsdesignpatterns.com/blog/node-js-race-conditions/](https://www.nodejsdesignpatterns.com/blog/node-js-race-conditions/)