### PR TITLE
addBoxAndUpdateSiteDetails, getSiteMostRecentBoxId

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -255,6 +255,7 @@ const biospecimenAPIs = async (req, res) => {
 
         return res.status(400).json(getResponseJSON('Bad request!', 400));
     }
+    //TODO: remove this endpoint after Aug 2023 push. Verify addBoxAndUpdateSiteDetails is working as expected.
     else if(api == 'addBox'){
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
@@ -273,6 +274,36 @@ const biospecimenAPIs = async (req, res) => {
             }
         }
         return res.status(200).json({message: 'Success!', code:200})
+    }
+    else if(api == 'addBoxAndUpdateSiteDetails'){
+        try {
+            if(req.method !== 'POST') {
+                return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+            }
+    
+            const requestData = req.body;
+            if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+
+            const boxId = requestData['132929440'];
+            const loginSite = requestData['789843387'];
+    
+            if (!boxId || !loginSite) {
+                return res.status(400).json(getResponseJSON('Required fields are missing!', 400));
+            }
+    
+            const { boxExists, addBoxAndUpdateSiteDetails } = require('./firestore');
+            const exists = await boxExists(boxId, loginSite);
+    
+            if (exists === true) {
+                return res.status(409).json(getResponseJSON('Conflict: Box already exists!', 409));
+            } else if (exists === false) {
+                await addBoxAndUpdateSiteDetails(requestData);
+                return res.status(200).json({message: 'Success!', code:200});
+            }
+        } catch (error) {
+            console.error("Error in addBoxAndUpdateSiteDetails endpoint:", error.message);
+            return res.status(500).json(getResponseJSON('Internal Server Error', 500));
+        }
     }
     else if(api == 'updateBox'){
         if(req.method !== 'POST') {
@@ -505,6 +536,22 @@ const biospecimenAPIs = async (req, res) => {
         return res.status(200).json({data: response, code:200})
     }
 
+    else if(api === 'getSiteMostRecentBoxId'){
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        try {
+            const {getSiteMostRecentBoxId} = require('./firestore');
+            const response = await getSiteMostRecentBoxId(siteCode);
+            if(!response) {
+                return res.status(404).json(getResponseJSON('No matching document found!', 404));
+            }
+            return res.status(200).json({data: response, code: 200});
+        } catch (error) {
+            console.error("Error fetching site most recent box ID:", error);
+            return res.status(500).json(getResponseJSON('Internal Server Error', 500));
+        }
+    }
      // Print Addresses POST- BPTL
     else if(api == 'printAddresses'){
         if(req.method !== 'POST') {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -275,7 +275,7 @@ const biospecimenAPIs = async (req, res) => {
         }
         return res.status(200).json({message: 'Success!', code:200})
     }
-    else if(api == 'addBoxAndUpdateSiteDetails'){
+    else if(api === 'addBoxAndUpdateSiteDetails'){
         try {
             if(req.method !== 'POST') {
                 return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -11,7 +11,7 @@ module.exports = {
         healthPartnersResearchClinic: 531629870,
         henryFordHealthSystem: 548392715,
         nationalInstitutesOfHealth: 13,
-    },
+    },//NORC?
 
     yes: 353358909,
     no: 104430631,

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -11,7 +11,7 @@ module.exports = {
         healthPartnersResearchClinic: 531629870,
         henryFordHealthSystem: 548392715,
         nationalInstitutesOfHealth: 13,
-    },//NORC?
+    },
 
     yes: 353358909,
     no: 104430631,

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -25,6 +25,7 @@ module.exports = {
     duplicate: 922622075,
     cannotBeVerified: 219863910,
     outreachTimeOut: 160161595,
+    shippingBoxId: 132929440,
 
     tubesBagsCids: {
         serumSeparatorTube1: 299553921,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1074,7 +1074,7 @@ const addBoxAndUpdateSiteDetails = async (data) => {
         return true;
     } catch (error) {
         console.error("Error in addBoxAndUpdateSiteDetails:", error.message);
-        throw new Error(error);
+        throw new Error('Error in addBoxAndUpdateSiteDetails', { cause: error });
     }
 }
 
@@ -1808,8 +1808,8 @@ const getSiteMostRecentBoxId = async (siteCode) => {
         }
         return null;
     } catch (error) {
-        console.error(error);
-        return new Error(error);
+        console.error('Error in getSiteMostRecentBoxId', error);
+        throw new Error('Error getting site most recent box id', { cause: error });
     }
 }
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1057,7 +1057,7 @@ const addBoxAndUpdateSiteDetails = async (data) => {
             throw new Error("siteDetailsDocRef is not provided in the data object.");
         }
 
-        const boxIdString = data['132929440'];
+        const boxIdString = data[fieldMapping.shippingBoxId];
         if (!boxIdString || typeof boxIdString !== 'string') {
             throw new Error("Invalid or missing BoxId value in the data object.");
         }


### PR DESCRIPTION
Update handling for new box creation in the Biospecimen shipping dashboard.

Related: https://github.com/episphere/connect/issues/685

Previously, boxIds were generated by getting all boxes for a site, iterating them, finding the highest boxId, and incrementing by one.

Now, we're switching to a more efficient method:

`getSiteMostRecentBoxId` gets the site's `docId` and `mostRecentBoxId` from the `siteDetails` collection.
`docId` is used to access and update the firestore doc.
`mostRecentBoxId` will be incremented client-side and updated on box creation with `addBoxAndUpdateSiteDetails`. 
`addBoxAndUpdateSiteDetails` performs a batch operation to:
(1) Create a new box in the `boxes` collection, and
(2) Log that box's id as a numeric value in the site's doc in the `siteDetails` collection for quick access when the next box needs to be created.

These two operations eliminate the need to pull all boxes, iterate them, etc.