### PR TITLE
Remove string support in name search

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -827,18 +827,18 @@ const filterDB = async (queries, siteCode, isParent) => {
     // Direct the generation and execution of queries based on the search properties present. If neither firstName nor lastName are present, this function is bypassed.
     const handleNameQueries = async (firstNameQuery, lastNameQuery, phoneEmailQuery) => {
         if (firstNameQuery) {
-            const fNameStringQueryForSearch = generateQuery(firstNameQuery, 'string');
-            await executeQuery(fNameStringQueryForSearch);
+            // const fNameStringQueryForSearch = generateQuery(firstNameQuery, 'string');
+            // await executeQuery(fNameStringQueryForSearch);
 
-            const fNameArrayQueryForSearch = generateQuery(firstNameQuery, 'array');
+            const fNameArrayQueryForSearch = generateQuery(firstNameQuery/*, 'array'*/);
             await executeQuery(fNameArrayQueryForSearch);
         }
 
         if (lastNameQuery) {
-            const lNameStringQueryForSearch = generateQuery(lastNameQuery, 'string');
-            await executeQuery(lNameStringQueryForSearch);
+            // const lNameStringQueryForSearch = generateQuery(lastNameQuery, 'string');
+            // await executeQuery(lNameStringQueryForSearch);
 
-            const lNameArrayQueryForSearch = generateQuery(lastNameQuery, 'array');
+            const lNameArrayQueryForSearch = generateQuery(lastNameQuery/*, 'array'*/);
             await executeQuery(lNameArrayQueryForSearch);
         }
 
@@ -849,15 +849,15 @@ const filterDB = async (queries, siteCode, isParent) => {
     };
 
     // Generate the queries. nameType is either 'string' or 'array' and applies to firstName and lastName properties.
-    const generateQuery = (queryKeys, nameType) => {
+    const generateQuery = (queryKeys/*, nameType*/) => {
         let participantQuery = collection;
 
         for (let key in queryKeys) {
             if (key === 'firstName' || key === 'lastName') {
                 const path = `query.${key}`;
                 const queryValue = key === 'firstName' ? queries.firstName : queries.lastName;
-                const operation = (nameType === 'string') ? '==' : 'array-contains';
-                participantQuery = participantQuery.where(path, operation, queryValue);
+                //const operation = /*(nameType === 'string') ? '==' :*/ 'array-contains';
+                participantQuery = participantQuery.where(path, 'array-contains', queryValue);
             }
             if (key === 'email' || key === 'phone') {
                 const path = `query.${key === 'email' ? 'allEmails' : 'allPhoneNo'}`;
@@ -907,12 +907,12 @@ const filterDB = async (queries, siteCode, isParent) => {
             return (!queries.firstName || participant.query.firstName.includes(queries.firstName)) &&
                 (!queries.lastName || participant.query.lastName.includes(queries.lastName)) &&
                 (!queries.email || participant.query.allEmails.includes(queries.email)) &&
-                (!queries.phone || participant.query.allPhoneNo.includes(queries.phone)) &&
-                (!queries.dob || participant['371067537'] === queries.dob) &&
-                (!queries.connectId || participant.Connect_ID === parseInt(queries.connectId)) &&
-                (!queries.token || participant.token === queries.token) &&
-                (!queries.studyId || participant.state.studyId === queries.studyId) &&
-                (!queries.checkedIn || participant['331584571.266600170.135591601'] === 353358909);
+                (!queries.phone || participant.query.allPhoneNo.includes(queries.phone)) //&&
+                // (!queries.dob || participant['371067537'] === queries.dob) &&
+                // (!queries.connectId || participant.Connect_ID === parseInt(queries.connectId)) &&
+                // (!queries.token || participant.token === queries.token) &&
+                // (!queries.studyId || participant.state.studyId === queries.studyId) &&
+                // (!queries.checkedIn || participant['331584571.266600170.135591601'] === 353358909);
         });
     };
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -803,10 +803,9 @@ const retrieveSiteNotifications = async (siteId, isParent) => {
 
 /**
  * Retrieve a list of participants from the database.
- * If name is in the query, we handle two cases: typeof(participantDoc.query.firstName) === 'string' and typeof(participantDoc.query.firstName) === 'array'.
- * If string, do a simple query.where('query.firstName', '==', queries.firstName.toLowerCase()). If array, we have to do a query.where('query.firstName', 'array-contains', queries.firstName.toLowerCase()).
- * Only one 'array-contains' operation can be done per query, so separate queries are required if both firstName and lastName are in the query. We also use array-contains for email and phone number. Note: only email or phone can be included in a query, not both.
- * TODO Future: if we (1) adjust signup to write query.firstName and query.lastName as arrays, and (2) update existing participant docs, we can remove the 'string' searches for firstName and lastName.
+ * If name is in the query, we handle the typeof(participantDoc.query.firstName) === 'array' case with firestore's 'array-contains' operator.
+ * Only one 'array-contains' operation can be done per query, so separate queries are required if both firstName and lastName are in the query.
+ * We also use array-contains for email and phone number. Note: only email or phone can be included in a query, not both.
  */
 const filterDB = async (queries, siteCode, isParent) => {
 
@@ -826,37 +825,34 @@ const filterDB = async (queries, siteCode, isParent) => {
 
     // Direct the generation and execution of queries based on the search properties present. If neither firstName nor lastName are present, this function is bypassed.
     const handleNameQueries = async (firstNameQuery, lastNameQuery, phoneEmailQuery) => {
-        if (firstNameQuery) {
-            // const fNameStringQueryForSearch = generateQuery(firstNameQuery, 'string');
-            // await executeQuery(fNameStringQueryForSearch);
+        const promises = [];
 
-            const fNameArrayQueryForSearch = generateQuery(firstNameQuery/*, 'array'*/);
-            await executeQuery(fNameArrayQueryForSearch);
+        if (firstNameQuery) {
+            const fNameArrayQueryForSearch = generateQuery(firstNameQuery);
+            promises.push(executeQuery(fNameArrayQueryForSearch));
         }
 
         if (lastNameQuery) {
-            // const lNameStringQueryForSearch = generateQuery(lastNameQuery, 'string');
-            // await executeQuery(lNameStringQueryForSearch);
-
-            const lNameArrayQueryForSearch = generateQuery(lastNameQuery/*, 'array'*/);
-            await executeQuery(lNameArrayQueryForSearch);
+            const lNameArrayQueryForSearch = generateQuery(lastNameQuery);
+            promises.push(executeQuery(lNameArrayQueryForSearch));
         }
 
         if (phoneEmailQuery) {
             const phoneOrEmailQueryForSearch = generateQuery(phoneEmailQuery);
-            await executeQuery(phoneOrEmailQueryForSearch);
+            promises.push(executeQuery(phoneOrEmailQueryForSearch));
         }
+
+        await Promise.all(promises);
     };
 
-    // Generate the queries. nameType is either 'string' or 'array' and applies to firstName and lastName properties.
-    const generateQuery = (queryKeys/*, nameType*/) => {
+    // Generate the queries.
+    const generateQuery = (queryKeys) => {
         let participantQuery = collection;
 
         for (let key in queryKeys) {
             if (key === 'firstName' || key === 'lastName') {
                 const path = `query.${key}`;
                 const queryValue = key === 'firstName' ? queries.firstName : queries.lastName;
-                //const operation = /*(nameType === 'string') ? '==' :*/ 'array-contains';
                 participantQuery = participantQuery.where(path, 'array-contains', queryValue);
             }
             if (key === 'email' || key === 'phone') {
@@ -907,18 +903,13 @@ const filterDB = async (queries, siteCode, isParent) => {
             return (!queries.firstName || participant.query.firstName.includes(queries.firstName)) &&
                 (!queries.lastName || participant.query.lastName.includes(queries.lastName)) &&
                 (!queries.email || participant.query.allEmails.includes(queries.email)) &&
-                (!queries.phone || participant.query.allPhoneNo.includes(queries.phone)) //&&
-                // (!queries.dob || participant['371067537'] === queries.dob) &&
-                // (!queries.connectId || participant.Connect_ID === parseInt(queries.connectId)) &&
-                // (!queries.token || participant.token === queries.token) &&
-                // (!queries.studyId || participant.state.studyId === queries.studyId) &&
-                // (!queries.checkedIn || participant['331584571.266600170.135591601'] === 353358909);
+                (!queries.phone || participant.query.allPhoneNo.includes(queries.phone))
         });
     };
 
     // Control flow for the participant query
-    // If two or more of firstName, lastName, and (email or phone) are included in the query, run multiple queries. Handle the string and array cases for participantDoc.query.firstName and participantDoc.query.lastName
-    // If only firstName or lastName is in the query (no phone or email), handle the string and array cases for participantDoc.query.firstName and participantDoc.query.lastName
+    // If two or more of firstName, lastName, and (email or phone) are included in the query, run multiple queries.
+    // If only firstName or lastName is in the query (no phone or email), handle the array case for participantDoc.query.firstName or participantDoc.query.lastName
     // If compound queries are executed, handle results including duplicates and the mismatches caused by executing multiple queries.
     // If neither firstName nor lastName are in the query, run a simple query that doesn't need post-processing. This is the else statement, return early.
     const collection = db.collection('participants');

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -825,24 +825,24 @@ const filterDB = async (queries, siteCode, isParent) => {
 
     // Direct the generation and execution of queries based on the search properties present. If neither firstName nor lastName are present, this function is bypassed.
     const handleNameQueries = async (firstNameQuery, lastNameQuery, phoneEmailQuery) => {
-        const promises = [];
+        const searchPromises = [];
 
         if (firstNameQuery) {
             const fNameArrayQueryForSearch = generateQuery(firstNameQuery);
-            promises.push(executeQuery(fNameArrayQueryForSearch));
+            searchPromises.push(executeQuery(fNameArrayQueryForSearch));
         }
 
         if (lastNameQuery) {
             const lNameArrayQueryForSearch = generateQuery(lastNameQuery);
-            promises.push(executeQuery(lNameArrayQueryForSearch));
+            searchPromises.push(executeQuery(lNameArrayQueryForSearch));
         }
 
         if (phoneEmailQuery) {
             const phoneOrEmailQueryForSearch = generateQuery(phoneEmailQuery);
-            promises.push(executeQuery(phoneOrEmailQueryForSearch));
+            searchPromises.push(executeQuery(phoneOrEmailQueryForSearch));
         }
 
-        await Promise.all(promises);
+        await Promise.all(searchPromises);
     };
 
     // Generate the queries.


### PR DESCRIPTION
Related issue: https://github.com/episphere/connect/issues/654

Cleanup from July release:
We previously supported string and array search for `query.firstName` and `query.lastName` variables in the participant profile. Those have since been converted to arrays. This PR:
•removes string support for search (this saves one query for single name search and 2 queries for full name search).
•uses Promises.all() for query execution when multiple 'array-contains' searches are included (firstName, lastName, phone, email).

I updated comments to reflect the new search structure and removed references to string support for name search.

