### PR TITLE
Notifications: Added else if clause for users with both email & phone login method

### DIFF
--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -207,18 +207,20 @@ const notificationHandler = async (message) => {
                 
                 if(participant[995036844] === 'phone' && participant[348474836]) {
                     loginDetails = participant[348474836];
-                    loginDetails = "***-***-" + loginDetails.substring(loginDetails.length - 4);
+                    loginDetails = `You may sign in to MyConnect app using ` + redactPhoneLoginInfo(loginDetails) + `.`;
                 }
                 else if(participant[995036844] === 'password' && participant[421823980]) {
                     loginDetails = participant[421823980];
-
-                    let amp = loginDetails.indexOf('@');    
-                    for(let i = 0; i < amp; i++) {
-                        if(i != 0 && i != 1 && i != amp - 1) {
-                            loginDetails = loginDetails.substring(0, i) + "*" + loginDetails.substring(i + 1);
-                        } 
-                    }
+                    loginDetails = `You may sign in to MyConnect app using ` + redactEmailLoginInfo(loginDetails) + `.`
+                }
+                else if(participant[995036844] === 'passwordAndPhone' && participant[421823980] && participant[348474836]) {
+                    let emailLoginDetails = participant[421823980];
+                    let phoneLoginDetails = participant[348474836];
                     
+                    emailLoginDetails = redactEmailLoginInfo(emailLoginDetails)
+                    phoneLoginDetails = redactPhoneLoginInfo(phoneLoginDetails);
+
+                    loginDetails = `You may sign in to MyConnect app using ` + emailLoginDetails + ` or ` + phoneLoginDetails + `.`
                 }
                 else continue;
 

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -204,14 +204,15 @@ const notificationHandler = async (message) => {
 
             if(body.indexOf('<loginDetails>') !== -1) {
                 let loginDetails;
+                const addLoginText = `Your login information for the MyConnect app is `
                 
                 if(participant[995036844] === 'phone' && participant[348474836]) {
                     loginDetails = participant[348474836];
-                    loginDetails = `You may sign in to MyConnect app using ` + redactPhoneLoginInfo(loginDetails) + `.`;
+                    loginDetails = addLoginText + redactPhoneLoginInfo(loginDetails) + `.`;
                 }
                 else if(participant[995036844] === 'password' && participant[421823980]) {
                     loginDetails = participant[421823980];
-                    loginDetails = `You may sign in to MyConnect app using ` + redactEmailLoginInfo(loginDetails) + `.`
+                    loginDetails = addLoginText + redactEmailLoginInfo(loginDetails) + `.`
                 }
                 else if(participant[995036844] === 'passwordAndPhone' && participant[421823980] && participant[348474836]) {
                     let emailLoginDetails = participant[421823980];
@@ -220,7 +221,7 @@ const notificationHandler = async (message) => {
                     emailLoginDetails = redactEmailLoginInfo(emailLoginDetails)
                     phoneLoginDetails = redactPhoneLoginInfo(phoneLoginDetails);
 
-                    loginDetails = `You may sign in to MyConnect app using ` + emailLoginDetails + ` or ` + phoneLoginDetails + `.`
+                    loginDetails = addLoginText + emailLoginDetails + ` or ` + phoneLoginDetails + `.`
                 }
                 else continue;
 

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -207,21 +207,13 @@ const notificationHandler = async (message) => {
                 const addLoginText = `Your login information for the MyConnect app is `
                 
                 if(participant[995036844] === 'phone' && participant[348474836]) {
-                    loginDetails = participant[348474836];
-                    loginDetails = addLoginText + redactPhoneLoginInfo(loginDetails) + `.`;
+                    loginDetails = addLoginText + redactPhoneLoginInfo(participant[348474836]) + `.`;
                 }
                 else if(participant[995036844] === 'password' && participant[421823980]) {
-                    loginDetails = participant[421823980];
-                    loginDetails = addLoginText + redactEmailLoginInfo(loginDetails) + `.`
+                    loginDetails = addLoginText + redactEmailLoginInfo(participant[421823980]) + `.`
                 }
                 else if(participant[995036844] === 'passwordAndPhone' && participant[421823980] && participant[348474836]) {
-                    let emailLoginDetails = participant[421823980];
-                    let phoneLoginDetails = participant[348474836];
-                    
-                    emailLoginDetails = redactEmailLoginInfo(emailLoginDetails)
-                    phoneLoginDetails = redactPhoneLoginInfo(phoneLoginDetails);
-
-                    loginDetails = addLoginText + emailLoginDetails + ` or ` + phoneLoginDetails + `.`
+                    loginDetails = addLoginText + redactEmailLoginInfo(participant[421823980]) + ` or ` + redactPhoneLoginInfo(participant[348474836]) + `.`
                 }
                 else continue;
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -757,6 +757,18 @@ const isDateTimeFormat = (value) => {
     return typeof value == "string" && (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(value));
 }
 
+const redactEmailLoginInfo = (loginDetails) => {
+    let amp = loginDetails.indexOf('@');    
+    for(let i = 0; i < amp; i++) {
+        if(i != 0 && i != 1 && i != amp - 1) {
+            loginDetails = loginDetails.substring(0, i) + "*" + loginDetails.substring(i + 1);
+        } 
+    }
+    return loginDetails
+}
+
+const redactPhoneLoginInfo = (loginDetails) => { return loginDetails = "***-***-" + loginDetails.substring(loginDetails.length - 4); }
+
 module.exports = {
     getResponseJSON,
     setHeaders,
@@ -791,5 +803,7 @@ module.exports = {
     batchLimit,
     getUserProfile,
     isEmpty,
-    isDateTimeFormat
+    isDateTimeFormat,
+    redactEmailLoginInfo,
+    redactPhoneLoginInfo
 }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -757,17 +757,15 @@ const isDateTimeFormat = (value) => {
     return typeof value == "string" && (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(value));
 }
 
-const redactEmailLoginInfo = (loginDetails) => {
-    let amp = loginDetails.indexOf('@');    
-    for(let i = 0; i < amp; i++) {
-        if(i != 0 && i != 1 && i != amp - 1) {
-            loginDetails = loginDetails.substring(0, i) + "*" + loginDetails.substring(i + 1);
-        } 
-    }
-    return loginDetails
+const redactEmailLoginInfo = (participantEmail) => {
+    const [prefix, domain] = participantEmail.split("@");
+    const changedPrefix = prefix.length > 3
+        ? prefix.slice(0, 2) + "*".repeat(prefix.length - 3) + prefix.slice(-1)
+        : prefix.slice(0, -1) + "*";
+    return changedPrefix + "@" + domain;
 }
 
-const redactPhoneLoginInfo = (loginDetails) => { return loginDetails = "***-***-" + loginDetails.substring(loginDetails.length - 4); }
+const redactPhoneLoginInfo = (participantPhone) => { return participantPhone = "***-***-" + participantPhone.substring(participantPhone.length - 4); }
 
 module.exports = {
     getResponseJSON,

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -765,7 +765,7 @@ const redactEmailLoginInfo = (participantEmail) => {
     return changedPrefix + "@" + domain;
 }
 
-const redactPhoneLoginInfo = (participantPhone) => { return participantPhone = "***-***-" + participantPhone.substring(participantPhone.length - 4); }
+const redactPhoneLoginInfo = (participantPhone) => { return participantPhone = "***-***-" + participantPhone.slice(-4); }
 
 module.exports = {
     getResponseJSON,

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -765,7 +765,7 @@ const redactEmailLoginInfo = (participantEmail) => {
     return changedPrefix + "@" + domain;
 }
 
-const redactPhoneLoginInfo = (participantPhone) => { return participantPhone = "***-***-" + participantPhone.slice(-4); }
+const redactPhoneLoginInfo = (participantPhone) => { return "***-***-" + participantPhone.slice(-4); }
 
 module.exports = {
     getResponseJSON,


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/connect/issues/689

When notifications (esp. emails) are sent out for users with both email & phone login method. The `<loginDetails>` in email is shown as undefined. To prevent this added else if clause to capture users with both login methods.

- Modularized functions that redact email & phone. 
- Returns following statements:
    Email Login: `Your login information for the MyConnect app is ` + `email` + `.`;
    Phone Login: `Your login information for the MyConnect app is` + `phone` + `.`;
    Both Email & Phone Login: `Your login information for the MyConnect app is ` + `email` + `or` + `phone` + `.`;
    
PoC:

Used a workaround to see how the text renders:
  
Phone:
![Screenshot 2023-08-17 at 4 02 44 PM](https://github.com/episphere/connectFaas/assets/30497847/88317416-39fe-4e0a-ba38-e23c1e1f4d96)

Email:
![Screenshot 2023-08-17 at 4 38 23 PM](https://github.com/episphere/connectFaas/assets/30497847/ec83158e-c9b4-4e3d-a274-66ac8b9e67bd)

Both Phone & Email:
![Screenshot 2023-08-17 at 4 40 18 PM](https://github.com/episphere/connectFaas/assets/30497847/cbaf3093-fda7-417c-997e-436f7ca8a19a)



  