### PR TITLE
[#658] Delete data from surveys and speciments

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -9,7 +9,13 @@ admin.initializeApp(functions.config().firebase);
 const db = admin.firestore();
 const increment = admin.firestore.FieldValue.increment(1);
 const decrement = admin.firestore.FieldValue.increment(-1);
-const { collectionIdConversion, bagConceptIDs, swapObjKeysAndValues, batchLimit } = require('./shared');
+const {
+    collectionIdConversion,
+    bagConceptIDs,
+    swapObjKeysAndValues,
+    batchLimit,
+    listOfCollectionsRelatedToDataDestruction,
+} = require("./shared");
 const fieldMapping = require('./fieldToConceptIdMapping');
 const { isIsoDate } = require('./validation');
 const nciCode = 13;
@@ -394,23 +400,8 @@ const retrieveParticipantsEligibleForIncentives = async (siteCode, roundType, is
 
 const removeDocumentFromCollection = async (connectID) => {
     try {
-        // Collections with document related to participant
-        const collectionArray = [
-            "bioSurvey_v1",
-            "clinicalBioSurvey_v1",
-            "covid19Survey_v1",
-            "menstrualSurvey_v1",
-            "module1_v1",
-            "module1_v2",
-            "module2_v1",
-            "module2_v2",
-            "module3_v1",
-            "module4_v1",
-            "ssn",
-            "biospecimen",
-        ];
-        while (collectionArray.length > 0) {
-            const collection = collectionArray.shift();
+        while (listOfCollectionsRelatedToDataDestruction.length > 0) {
+            const collection = listOfCollectionsRelatedToDataDestruction.shift();
             const data = await db
                 .collection(collection)
                 .where("Connect_ID", "==", connectID)

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -392,6 +392,36 @@ const retrieveParticipantsEligibleForIncentives = async (siteCode, roundType, is
     }
 }
 
+const removeDocumentFromCollection = async (connectID) => {
+    // Collections with document related to participant
+    const collectionArray = [
+        "bioSurvey_v1",
+        "clinicalBioSurvey_v1",
+        "covid19Survey_v1",
+        "menstrualSurvey_v1",
+        "module1_v1",
+        "module1_v2",
+        "module2_v1",
+        "module2_v2",
+        "module3_v1",
+        "module4_v1",
+        "ssn",
+        "biospecimen",
+    ];
+    while (collectionArray.length > 0) {
+        const collection = collectionArray.shift();
+        const data = await db
+            .collection(collection)
+            .where("Connect_ID", "==", connectID)
+            .get();
+        if (data.size !== 0) {
+            data.docs.forEach(async (dt) => {
+                await db.collection(collection).doc(dt.id).delete();
+            });
+        }
+    }
+};
+
 /**
  * This function is run every day at 01:00.
  * This function is used to delete the data of the participant who requested and signed the data destruction form or requested data destruction within 60 days
@@ -469,6 +499,7 @@ const removeParticipantsDataDestruction = async () => {
                 }
             }
             await batch.commit();
+            await removeDocumentFromCollection(participant['Connect_ID']);
         }
 
         console.log(

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -393,32 +393,36 @@ const retrieveParticipantsEligibleForIncentives = async (siteCode, roundType, is
 }
 
 const removeDocumentFromCollection = async (connectID) => {
-    // Collections with document related to participant
-    const collectionArray = [
-        "bioSurvey_v1",
-        "clinicalBioSurvey_v1",
-        "covid19Survey_v1",
-        "menstrualSurvey_v1",
-        "module1_v1",
-        "module1_v2",
-        "module2_v1",
-        "module2_v2",
-        "module3_v1",
-        "module4_v1",
-        "ssn",
-        "biospecimen",
-    ];
-    while (collectionArray.length > 0) {
-        const collection = collectionArray.shift();
-        const data = await db
-            .collection(collection)
-            .where("Connect_ID", "==", connectID)
-            .get();
-        if (data.size !== 0) {
-            data.docs.forEach(async (dt) => {
-                await db.collection(collection).doc(dt.id).delete();
-            });
+    try {
+        // Collections with document related to participant
+        const collectionArray = [
+            "bioSurvey_v1",
+            "clinicalBioSurvey_v1",
+            "covid19Survey_v1",
+            "menstrualSurvey_v1",
+            "module1_v1",
+            "module1_v2",
+            "module2_v1",
+            "module2_v2",
+            "module3_v1",
+            "module4_v1",
+            "ssn",
+            "biospecimen",
+        ];
+        while (collectionArray.length > 0) {
+            const collection = collectionArray.shift();
+            const data = await db
+                .collection(collection)
+                .where("Connect_ID", "==", connectID)
+                .get();
+            if (data.size !== 0) {
+                for (const dt of data.docs) {
+                    await db.collection(collection).doc(dt.id).delete();
+                }
+            }
         }
+    } catch (error) {
+        console.error(`Error occurred when remove documents related to participan: ${error}`);
     }
 };
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -263,6 +263,20 @@ const moduleStatusConcepts = {
     "253883960" :       "clinicalBioSurvey"
 }
 
+const listOfCollectionsRelatedToDataDestruction = [
+    "bioSurvey_v1",
+    "clinicalBioSurvey_v1",
+    "covid19Survey_v1",
+    "menstrualSurvey_v1",
+    "module1_v1",
+    "module1_v2",
+    "module2_v1",
+    "module2_v2",
+    "module3_v1",
+    "module4_v1",
+    "biospecimen",
+];
+
 const incentiveConcepts = {
     'baseline': '130371375.266600170',
     'followup1': '130371375.496823485',
@@ -771,6 +785,7 @@ module.exports = {
     moduleConcepts,
     moduleConceptsToCollections,
     moduleStatusConcepts,
+    listOfCollectionsRelatedToDataDestruction,
     incentiveConcepts,
     APIAuthorization,
     isParentEntity,


### PR DESCRIPTION
This PR addresses comment https://github.com/episphere/connect/issues/658#issuecomment-1684110577 from issue https://github.com/episphere/connect/issues/658.

- Added function `removeDocumentFromCollection` to delete all data that relates to participant data destruction from these collections `"bioSurvey_v1", "clinicalBioSurvey_v1", "covid19Survey_v1", "menstrualSurvey_v1", "module1_v1", "module1_v2", "module2_v1", "module2_v2", "module3_v1", "module4_v1", "ssn", "biospecimen"`