### PR TITLE
Biospecimen Dashboard: Added API endpoints to query participants for Daily Reports Page (Part 2)

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2132,7 +2132,7 @@ const queryDailyReportParticipants = async () => {
     const twoDaysAgo = new Date(new Date().getTime() - (twoDaysinMilliseconds)).toISOString();
     let query = db.collection('participants');
     try {
-        const snapshot = await query.where('331584571.266600170.135591601', '==', 353358909).where('331584571.266600170.840048338', '<', twoDaysAgo).get();
+        const snapshot = await query.where('331584571.266600170.135591601', '==', 353358909).where('331584571.266600170.840048338', '>=', twoDaysAgo).get();
         if (snapshot.size !== 0) {
             const promises = snapshot.docs.map(async (document) => {
                 return processQueryDailyReportParticipants(document);
@@ -2143,7 +2143,7 @@ const queryDailyReportParticipants = async () => {
         }
     }
     catch(error) {
-        return error.errorInfo.code
+        return error.errorInfo
     }
 };
 
@@ -2168,7 +2168,7 @@ const processQueryDailyReportParticipants = async (document) => {
         }
     }
     catch(error) {
-        return error.errorInfo.code
+        return error.errorInfo
     }
 };
 


### PR DESCRIPTION
Title^^
This PR addresses following issue:
https://github.com/episphere/connect/issues/631
- Fixed logic for Participants record that need to be removed from the table after 2 days of check-in
Related PR:
https://github.com/episphere/biospecimen/pull/569

Logic Evaulation:

```
Check In Date, '>=', twoDaysAgo from current date
22 aug          >=     20 aug

22 aug           >=    21 aug

22 aug          >=     22 aug

22 aug   !== 23 aug // record removed from the table
```