### PR TITLE
bux fixes on PR#401

### DIFF
--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -76,8 +76,8 @@ async function getParticipantsForNotificationsBQ({
     result.hasNext = rows.length === limit;
     result.fetchedDataArray = rows.map((data) => convertToFirestoreData(data, dotPlaceholder));
     return result;
-  } catch (error) { // Error occurs on missing filed(s) in BQ table.
-    console.log(`getParticipantsForNotificationsBQ() error running spec ID ${notificationSpecId}`, error);
+  } catch (error) { // Error occurs on missing field(s) in BQ table.
+    console.log(`getParticipantsForNotificationsBQ() error running spec ID ${notificationSpecId}.`, error);
     return result;
   }
 }

--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -76,8 +76,9 @@ async function getParticipantsForNotificationsBQ({
     result.hasNext = rows.length === limit;
     result.fetchedDataArray = rows.map((data) => convertToFirestoreData(data, dotPlaceholder));
     return result;
-  } catch (error) {
-    throw new Error("getParticipantsForNotificationsBQ() error.", {cause: error});
+  } catch (error) { // Error occurs on missing filed(s) in BQ table.
+    console.log(`getParticipantsForNotificationsBQ() error running spec ID ${notificationSpecId}`, error);
+    return result;
   }
 }
 

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -256,7 +256,6 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
       };
 
       notificationRecordArray.push(notificationRecord);
-      emailCount++;
     }
 
     if (personalizationArray.length === 0) continue;
@@ -275,8 +274,10 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
       await sgMail.send(msgBatch);
     } catch (error) {
       console.error(`Error sending emails for ${notificationSpecId}(${messageSubject}).`, error);
-      return;
+      break;
     }
+
+    emailCount += personalizationArray.length;
 
     try {
       await Promise.all([
@@ -285,7 +286,7 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
       ]);
     } catch (error) {
       console.error(`Error saving data for ${notificationSpecId}(${messageSubject}).`, error);
-      return;
+      break;
     }
 
     offset += limit;


### PR DESCRIPTION
This PR fix bugs in PR [#401](https://github.com/episphere/connectFaas/pull/401). Below are details:
- Avoids using variables (firstNameField, preferredNameField, emailField) when not available in some notification specifications
- Handles BQ errors when occurred
- Put back `participantTokenArray` updates
- Other small things

These updates were tested locally with no problems found.