### PR TITLE
fix logic error in removeBag. Add error handling.

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -455,12 +455,22 @@ const biospecimenAPIs = async (req, res) => {
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
         }
+
         const {removeBag} = require('./firestore');
         const requestData = req.body;
         if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
 
-        await removeBag(siteCode, requestData);
-        return res.status(200).json({message: 'Success!', code:200});
+        try {
+            const result = await removeBag(siteCode, requestData);
+            if (result === 'Success!') {
+                return res.status(200).json({message: 'Success!', code:200});
+            } else {
+                return res.status(500).json({message: 'Failure. Could not remove bag.', code:500});
+            }
+        } catch (error) {
+            console.error('Error removing bag:', error);
+            return res.status(500).json({message: 'Error removing bag', code:500});
+        }
     }
     else if (api === 'reportMissingSpecimen'){
         if(req.method !== 'POST') {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1110,16 +1110,23 @@ const updateBox = async (id, data, loginSite) => {
     await db.collection('boxes').doc(docId).update(data);
 }
 
-
+/**
+ * Remove a bag from a box. Orphan tubes are treated as separate bags.
+ * @param {*} siteCode - Site code of the site where the box is located.
+ * @param {*} requestData - Single element array for regular bags and one element for stray tube for orphan bags.
+ * @returns - Success or Failure message.
+ */
 const removeBag = async (siteCode, requestData) => {
-    let boxId = requestData.boxId;
-    let bags = requestData.bags;
-    let currDate = requestData.date;
-    let hasOrphanFlag = 104430631; 
+    const boxId = requestData.boxId;
+    const bags = requestData.bags;
+    const currDate = requestData.date;
+    let hasOrphanFlag = 104430631;
+
     const snapshot = await db.collection('boxes').where('132929440', '==', boxId).where('789843387', '==',siteCode).get();
+    
     if(snapshot.size === 1){
-      let doc = snapshot.docs[0];
-      let box = doc.data();
+      const doc = snapshot.docs[0];
+      const box = doc.data();
       
       for (let conceptID of bagConceptIDs) { 
           const currBag = box[conceptID];
@@ -1131,38 +1138,44 @@ const removeBag = async (siteCode, requestData) => {
           }
       }
 
-      let bagConceptIDIndex = 0;
-      for (let k of Object.keys(box)) { 
-          if (bagConceptIDs.includes(k)) {
-              const currBagConceptID = bagConceptIDs[bagConceptIDIndex];
-              if (currBagConceptID === k) continue;
-              box[currBagConceptID] = box[k];
-              delete box[k];
-              bagConceptIDIndex++;
+      // Create a new sorted box
+      const sortedBox = {};
+      for (let conceptID of bagConceptIDs) {
+          const foundKey = Object.keys(box).find(k => bagConceptIDs.includes(k));
+          if (foundKey) {
+              sortedBox[conceptID] = box[foundKey];
+              delete box[foundKey];
           }
+      }
+
+      // Copy any remaining properties from the original box to the sorted box
+      for (let k of Object.keys(box)) {
+          sortedBox[k] = box[k];
       }
 
       // iterate over all current bag concept Ids and change the value of hasOrphanFlag
       for(let conceptID of bagConceptIDs) {
-        const currBag = box[conceptID];
+        const currBag = sortedBox[conceptID];
         if (!currBag) continue;
         if(currBag['255283733'] == 104430631 ) {
           hasOrphanFlag = 104430631;
-        }
-        else if (currBag['255283733'] == 353358909) {
+        } else if (currBag['255283733'] == 353358909) {
           hasOrphanFlag = 353358909;
-        }
-        else {
+        } else {
           hasOrphanFlag = 104430631;
         }
       }
       
-      await db.collection('boxes').doc(doc.id).set({ ...box, '555611076':currDate, '842312685':hasOrphanFlag  });
-      return 'Success!';
-    }
-    else {
+      try {
+        await db.collection('boxes').doc(doc.id).set({ ...sortedBox, '555611076':currDate, '842312685':hasOrphanFlag });
+        return 'Success!';
+      } catch (error) {
+        console.error('Error writing document: ', error);
+        throw new Error('Error updating the box in the database.');
+      }
+    } else {
       return 'Failure! Could not find box mentioned';
-  }   
+    }   
 }
 
 const reportMissingSpecimen = async (siteAcronym, requestData) => {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1139,7 +1139,7 @@ const removeBag = async (siteCode, requestData) => {
       }
 
       // Create a new sorted box
-      const sortedBox = {};
+      let sortedBox = {};
       for (let conceptID of bagConceptIDs) {
           const foundKey = Object.keys(box).find(k => bagConceptIDs.includes(k));
           if (foundKey) {
@@ -1148,10 +1148,8 @@ const removeBag = async (siteCode, requestData) => {
           }
       }
 
-      // Copy any remaining properties from the original box to the sorted box
-      for (let k of Object.keys(box)) {
-          sortedBox[k] = box[k];
-      }
+      // Merge remaining properties from the original box to the sorted box
+      sortedBox = { ...sortedBox, ...box }
 
       // iterate over all current bag concept Ids and change the value of hasOrphanFlag
       for(let conceptID of bagConceptIDs) {


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/685

Issue: We found a logic flaw in the existing `removeBag` function in ConnectFaas. An error in the iteration logic was causing bag overwrite depending on the position of the removed bag. This resulted in multiple bags being removed from a box in certain cases. This behavior was first brought up by a lab worker at HP 2 months ago and was reconfirmed in testing.

This function updates bag removal handling and adds error handling.
(1) Remove specified bag(s).
(2) Create new sortedBox.
(3) Iterate old box, placing foundKeys in order in the new sortedBox (Thing 1, Thing 2, Thing 3, etc...).
(4) Copy remaining keys to sortedBox and update firestore.