### PR TITLE
[#658 - Bug Fix] Not working if there are more than 2 participants

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -395,8 +395,7 @@ const retrieveParticipantsEligibleForIncentives = async (siteCode, roundType, is
 
 const removeDocumentFromCollection = async (connectID, token) => {
     try {
-        while (listOfCollectionsRelatedToDataDestruction.length > 0) {
-            const collection = listOfCollectionsRelatedToDataDestruction.shift();
+        for (const collection of listOfCollectionsRelatedToDataDestruction) {
             const query = db.collection(collection)
             const data =
                 collection === "notifications"


### PR DESCRIPTION
This PR addresses comment https://github.com/episphere/connect/issues/658#issuecomment-1697585534 of issue https://github.com/episphere/connect/issues/658

**Reason**: Using
 ```
while (listOfCollectionsRelatedToDataDestruction.length > 0) {
            const collection = listOfCollectionsRelatedToDataDestruction.shift();
```
=> `listOfCollectionsRelatedToDataDestruction` will be empty once running to the second participant.

**Solution** Using `for (const collection of listOfCollectionsRelatedToDataDestruction)` instead.