### PR TITLE
Biospecimen Dashboard: Update API endpoints to query participants for Daily Reports Page

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2251,6 +2251,8 @@ const queryDailyReportParticipants = async () => {
             return Promise.all(promises).then((results) => {
                 return results.filter((result) => result !== undefined);
             });
+        } else {
+            return []
         }
     }
     catch(error) {


### PR DESCRIPTION
Title^^
This PR addresses following issue:
- Returns an empty array when they're no participants to check-in. This prevents the UI form breaking on load.

Related PR:
https://github.com/episphere/biospecimen/pull/569
https://github.com/episphere/connectFaas/pull/403