### PR TITLE
add getSpecimens: ByCollectionIds & ByReceivedDate

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -472,6 +472,39 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(500).json({message: 'Error removing bag', code:500});
         }
     }
+    else if (api === 'getSpecimensByCollectionIds'){
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+
+        const collectionIdArray = req.query.collectionIdArray.split(',');
+        const isBPTL = req.query.isBPTL ?? false;
+        if (!collectionIdArray) return res.status(400).json(getResponseJSON('CollectionIdArray is missing.', 400));
+
+        try {
+            const { getSpecimensByCollectionIds } = require('./firestore');
+            const specimensList = await getSpecimensByCollectionIds(collectionIdArray, isBPTL, siteCode);
+            return res.status(200).json({data: specimensList, code:200});
+        } catch (error) {
+            return res.status(500).json({ message: `Internal Server Error running getSpecimensByCollectionIds(), ${error}`, code: 500 });
+        }
+    }
+    else if (api === 'getSpecimensByReceivedDate'){
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+
+        const receivedTimestamp = req.query.receivedTimestamp;
+        if (!receivedTimestamp) return res.status(400).json(getResponseJSON('Timestamp is missing.', 400));
+
+        try {
+            const { getSpecimensByReceivedDate } = require('./firestore');
+            const boxesByReceivedDateBPTL = await getSpecimensByReceivedDate(receivedTimestamp);
+            return res.status(200).json({data: boxesByReceivedDateBPTL, code:200});
+        } catch (error) {
+            return res.status(500).json({ message: `Internal Server Error running getSpecimensByReceivedDate(), ${error}`, code: 500 });
+        }
+    }
     else if (api === 'reportMissingSpecimen'){
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
@@ -482,8 +515,6 @@ const biospecimenAPIs = async (req, res) => {
 
         await reportMissingSpecimen(siteAcronym, requestData);
         return res.status(200).json({message: 'Success!', code:200});
- 
-
     }
     else if (api === 'getLocations'){
         if(req.method !== 'GET') {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -496,13 +496,14 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
 
+        if (!req.query.collectionIdArray) return res.status(400).json(getResponseJSON('CollectionIdArray is missing.', 400));
+
         const collectionIdArray = req.query.collectionIdArray.split(',');
         const isBPTL = req.query.isBPTL ?? false;
-        if (!collectionIdArray) return res.status(400).json(getResponseJSON('CollectionIdArray is missing.', 400));
 
         try {
             const { getSpecimensByCollectionIds } = require('./firestore');
-            const specimensList = await getSpecimensByCollectionIds(collectionIdArray, isBPTL, siteCode);
+            const specimensList = await getSpecimensByCollectionIds(collectionIdArray, siteCode, isBPTL);
             return res.status(200).json({data: specimensList, code:200});
         } catch (error) {
             return res.status(500).json({ message: `Internal Server Error running getSpecimensByCollectionIds(), ${error}`, code: 500 });

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -496,9 +496,9 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
 
-        if (!req.query.collectionIdArray) return res.status(400).json(getResponseJSON('CollectionIdArray is missing.', 400));
+        if (!req.query.collectionIdsArray) return res.status(400).json(getResponseJSON('collectionIdsArray is missing.', 400));
 
-        const collectionIdArray = req.query.collectionIdArray.split(',');
+        const collectionIdArray = req.query.collectionIdsArray.split(',');
         const isBPTL = req.query.isBPTL ?? false;
 
         try {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -514,8 +514,9 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
 
+        if (!req.query.receivedTimestamp) return res.status(400).json(getResponseJSON('Timestamp is missing.', 400));
+        
         const receivedTimestamp = req.query.receivedTimestamp;
-        if (!receivedTimestamp) return res.status(400).json(getResponseJSON('Timestamp is missing.', 400));
 
         try {
             const { getSpecimensByReceivedDate } = require('./firestore');

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2395,8 +2395,12 @@ const getSpecimensByReceivedDate = async (receivedTimestamp) => {
  * @returns list of boxes received on the given date.
  */
 const getBoxesByReceivedDate = async (receivedTimestamp) => {
-    const snapshot = await db.collection('boxes').where('926457119', '==', receivedTimestamp).get();
-    return snapshot.docs.map(doc => doc.data());
+    try {
+        const snapshot = await db.collection('boxes').where('926457119', '==', receivedTimestamp).get();
+        return snapshot.docs.map(doc => doc.data());
+    } catch (error) {
+        throw new Error("Error fetching boxes by received date.", { cause: error });
+    }
 }
 
 /**
@@ -2411,9 +2415,11 @@ const getBoxesByReceivedDate = async (receivedTimestamp) => {
 // Max 30 disjunctions for 'in' queries: array length <= 30 for BPTL, <= 15 for site due to extra .where() clause in site query 
 const getSpecimensByCollectionIds = async (collectionIdsArray, siteCode, isBPTL = false) => {
     const getSnapshot = (collectionIds) => {
-        return isBPTL
-            ? db.collection('biospecimen').where('820476880', 'in', collectionIds).get()
-            : db.collection('biospecimen').where('820476880', 'in', collectionIds).where('827220437', '==', siteCode).get();
+        let query = db.collection('biospecimen').where('820476880', 'in', collectionIds);
+        if (!isBPTL) {
+            query = query.where('827220437', '==', siteCode);
+        }
+        return query.get();
     }
 
     try {
@@ -2436,7 +2442,7 @@ const getSpecimensByCollectionIds = async (collectionIdsArray, siteCode, isBPTL 
         return resultsArray;
 
     } catch (error) {
-        throw new Error("Error fetching specimens by received date.", { cause: error });
+        throw new Error("Error fetching specimens by collectionIds.", { cause: error });
     }
 }
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2312,13 +2312,12 @@ const getSpecimensByReceivedDate = async (receivedTimestamp) => {
     try {
         const boxes = await getBoxesByReceivedDate(receivedTimestamp);
         const collectionIdArray = extractCollectionIdsFromBoxes(boxes);
-        console.log('collectionIdArray', collectionIdArray)
         if (collectionIdArray.length === 0) {
             return [];
         }
 
         const specimenCollections = await getSpecimensByCollectionIds(collectionIdArray, true);
-        const specimenData = processSpecimenCollections(specimenCollections, receivedTimestamp, tubeConceptIds);
+        const specimenData = processSpecimenCollections(specimenCollections, receivedTimestamp);
 
         return specimenData;
     } catch (error) {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2407,8 +2407,6 @@ const getBoxesByReceivedDate = async (receivedTimestamp) => {
  * @returns {array} - Array of biospecimen data objects.
  * Max 30 disjunctions for 'in' queries: array length <= 30 for BPTL, <= 15 for site due to extra .where() clause in site query 
  */
-// Get biospecimen docs from collectionIdsArray (conceptId: 820476880). Ex: ['CXA123456', 'CXA234567', 'CXA345678']
-// Max 30 disjunctions for 'in' queries: array length <= 30 for BPTL, <= 15 for site due to extra .where() clause in site query 
 const getSpecimensByCollectionIds = async (collectionIdsArray, siteCode, isBPTL = false) => {
     const getSnapshot = (collectionIds) => {
         let query = db.collection('biospecimen').where('820476880', 'in', collectionIds);

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2380,7 +2380,7 @@ const getSpecimensByReceivedDate = async (receivedTimestamp) => {
             return [];
         }
 
-        const specimenCollections = await getSpecimensByCollectionIds(collectionIdArray, true);
+        const specimenCollections = await getSpecimensByCollectionIds(collectionIdArray, null, true);
         const specimenData = processSpecimenCollections(specimenCollections, receivedTimestamp);
 
         return specimenData;
@@ -2395,12 +2395,8 @@ const getSpecimensByReceivedDate = async (receivedTimestamp) => {
  * @returns list of boxes received on the given date.
  */
 const getBoxesByReceivedDate = async (receivedTimestamp) => {
-    try {
-        const snapshot = await db.collection('boxes').where('926457119', '==', receivedTimestamp).get();
-        return snapshot.docs.map(doc => doc.data());
-    } catch (error) {
-        throw new Error("Error fetching boxes by received date.", { cause: error });
-    }
+    const snapshot = await db.collection('boxes').where('926457119', '==', receivedTimestamp).get();
+    return snapshot.docs.map(doc => doc.data());
 }
 
 /**

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -814,8 +814,12 @@ const tubeConceptIds = [
     '973670172', // Urine tube 1
 ];
 
-// Extract all the collectionIds from a list of boxes, return an array of unique collectionIds.
-// Bag types: 787237543 (Biohazard Blood/Urine), 223999569 (Biohazard Mouthwash), 522094118 (Orphan)
+/**
+ * Extract collectionIds from a list of boxes
+ * @param {array} boxesList - list of boxes to process
+ * @returns {array} - array of unique collectionIds
+ * Bag types: 787237543 (Biohazard Blood/Urine), 223999569 (Biohazard Mouthwash), 522094118 (Orphan)
+ */
 const extractCollectionIdsFromBoxes = (boxesList) => {
     const { bagConceptIDs } = require('./shared');
     const collectionIdSet = new Set();
@@ -823,9 +827,9 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
         for (const bag of bagConceptIDs) {
             if (box[bag]) {
                 const bagId = box[bag]['787237543'] || box[bag]['223999569'] || box[bag]['522094118'];
-                const collectionId = bagId.split(' ')[0];
-                if (collectionId) {
-                    collectionIdSet.add(collectionId);
+                if (bagId) {
+                    const collectionId = bagId.split(' ')[0];
+                    collectionId && collectionIdSet.add(collectionId);
                 }
             }
         }
@@ -836,7 +840,6 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
 // process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
 // return specimen data array with modified tube data
 const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
-    let tubeCount = 0;
     const specimenDataArray = [];
 
     for (const specimenCollection of specimenCollections) {
@@ -845,7 +848,6 @@ const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
         const filteredSpecimens = tubeConceptIds.reduce((acc, key) => {
             const tube = specimenCollection[key];
             if (tube && tube['926457119'] === receivedTimestamp) {
-                tubeCount++;
                 acc[key] = tube;
                 hasSpecimens = true;
             }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -837,7 +837,7 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
 
 // process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
 // return specimen data array with modified tube data
-const processSpecimenCollections = (specimenCollections, receivedTimestamp, tubeConceptIds) => {
+const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
     let tubeCount = 0;
     const specimenDataArray = [];
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -838,19 +838,19 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
 }
 
 /**
- * Process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
- * @param {array} specimenCollections - array of specimen collectionIds
+ * process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
+ * @param {array} specimenCollections - array of specimen collection data 
  * @param {*} receivedTimestamp - timestamp of the received date
- * @returns {array} - array of specimen data
+ * @returns {array} - modified specimen collection data array
  */
 const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
     const specimenDataArray = [];
 
     for (const specimenCollection of specimenCollections) {
         let hasSpecimens = false;
-
         const filteredSpecimens = tubeConceptIds.reduce((acc, key) => {
-            const tube = specimenCollection[key];
+            const tube = specimenCollection['data'][key];
+
             if (tube && tube['926457119'] === receivedTimestamp) {
                 acc[key] = tube;
                 hasSpecimens = true;
@@ -861,21 +861,20 @@ const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
         if (hasSpecimens) {
             specimenDataArray.push({
                 'specimens': filteredSpecimens,
-                '820476880': specimenCollection['820476880'],
-                '926457119': specimenCollection['926457119'],
-                '678166505': specimenCollection['678166505'],
-                '827220437': specimenCollection['827220437'],
-                '951355211': specimenCollection['951355211'],
-                '915838974': specimenCollection['915838974'],
-                '650516960': specimenCollection['650516960'],
-                'Connect_ID': specimenCollection['Connect_ID'],
+                '820476880': specimenCollection['data']['820476880'],
+                '926457119': specimenCollection['data']['926457119'],
+                '678166505': specimenCollection['data']['678166505'],
+                '827220437': specimenCollection['data']['827220437'],
+                '951355211': specimenCollection['data']['951355211'],
+                '915838974': specimenCollection['data']['915838974'],
+                '650516960': specimenCollection['data']['650516960'],
+                'Connect_ID': specimenCollection['data']['Connect_ID'],
             });
         }
     }
 
     return specimenDataArray;
 }
-
 
 module.exports = {
     getResponseJSON,

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -837,8 +837,12 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
     return Array.from(collectionIdSet);
 }
 
-// process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
-// return specimen data array with modified tube data
+/**
+ * Process fetched specimen collections, filter out tubes that are not received on the receivedTimestamp day.
+ * @param {array} specimenCollections - array of specimen collectionIds
+ * @param {*} receivedTimestamp - timestamp of the received date
+ * @returns {array} - array of specimen data
+ */
 const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
     const specimenDataArray = [];
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -822,9 +822,7 @@ const extractCollectionIdsFromBoxes = (boxesList) => {
     for (const box of boxesList) {
         for (const bag of bagConceptIDs) {
             if (box[bag]) {
-                //console.log(box[bag]);
                 const bagId = box[bag]['787237543'] || box[bag]['223999569'] || box[bag]['522094118'];
-                //console.log('bagId', bagId);
                 const collectionId = bagId.split(' ')[0];
                 if (collectionId) {
                     collectionIdSet.add(collectionId);


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/708

Adding endpoints: `getSpecimensByCollectionIds` and `getSpecimensByReceivedDate`

•`getSpecimensByReceivedDate` allows us to query specific boxes and then query only the specimens in those boxes. This will be used in the BPTL dashboard.
•`getSpecimensByCollectionIds` is a helper to `getSpecimensByReceivedDate` and is added as an endpoint for separate specimen search functionality.  