### PR TITLE
update ship API, add getBoxesById()

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -16,8 +16,13 @@ module.exports = {
     yes: 353358909,
     no: 104430631,
     healthCareProvider: 827220437,
+    loginSite: 789843387,
     reportMissingTube: 258745303,
     submitShipmentFlag: 145971562,
+    submitShipmentTimestamp: 656548982,
+    shippingBoxId: 132929440,
+    shipmentCourier: 666553960,
+    shipperEmail: 948887825,
     pinMatch: 948195369,
     verificationStatus: 821247024,
     notVerified: 875007964,
@@ -25,7 +30,8 @@ module.exports = {
     duplicate: 922622075,
     cannotBeVerified: 219863910,
     outreachTimeOut: 160161595,
-    shippingBoxId: 132929440,
+    temperatureProbeInBox: 105891443,
+    boxTrackingNumberScan: 959708259,
 
     tubesBagsCids: {
         serumSeparatorTube1: 299553921,


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/625
-The ship api has been failing intermittently with no error response. Boxes are not updated as shipped, so the site has to force the shipment with a fake tracking number. This is not ideal or scalable. 

-inspected and updated `ship` endpoint with notes.
-updated `shipBatchBoxes()` function to ensure shipped property is set and run as a Firestore transaction (atomic, ensures data integrity, automatically retries on initial failure).
-added `getBoxesById()` to support get requests on boxes with or without transaction. This will be useful in other scenarios as well.

Note: rules for firestore `'in'` query: max 30 disjunctions. This is preferred because it's sent as a single query. If over 30 disjunctions, we process the request with `Promise.all()`, which is sent as `n` queries.
Disjunctions = (items in array) * (where() clauses).

 