### PR TITLE
Fix searchSpecimenBySiteAndBoxId function

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -253,7 +253,7 @@ const biospecimenAPIs = async (req, res) => {
                 
             } catch (error) {
                 console.error('Error occurred when running searchSpecimenBySiteAndBoxId:', error);
-                return res.status(500).json({ data: {}, message: error, code: 500 });
+                return res.status(500).json({ data: [], message: error, code: 500 });
             }
         } else {
             const { searchShipments } = require('./firestore');

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1268,7 +1268,6 @@ const getSiteLocationBox = async (requestedSite, boxId) => {
 const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
     try {
         const shipBoxMatch = await getSiteLocationBox(requestedSite, boxId);
-
         if (shipBoxMatch === undefined || shipBoxMatch.length === 0) return [];
         
         const shipBoxObj = shipBoxMatch[0];
@@ -1276,13 +1275,12 @@ const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
         const bagConceptIdList = Object.values(fieldMapping.bagContainerCids);
 
         for (let key in shipBoxObj) {
-        // check if key is in bagConceptIdList array of conceptIds
+            // check if key is in bagConceptIdList array of conceptIds
             if (bagConceptIdList.includes(parseInt(key))) {
                 const bagContainerContent = shipBoxObj[key]; 
                 const bloodUrineScan = fieldMapping.tubesBagsCids.biohazardBagScan;
                 const mouthwashScan = fieldMapping.tubesBagsCids.biohazardMouthwashBagScan;
-                const orphanScan = fieldMapping.tubesBagsCids.biohazardMouthwashBagScan;
-
+                const orphanScan = fieldMapping.tubesBagsCids.orphanScan;
                 // Loop through the bagContainerContent to find the collectionId
                 for (let key in bagContainerContent) {
                     if (parseInt(key) === bloodUrineScan || 
@@ -1290,7 +1288,7 @@ const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
                         parseInt(key) === orphanScan) {
                         if (bagContainerContent[key] !== '') {
                             // extract the collectionId and push to collectionIdArray
-                            const collectionIdString = bagContainerContent[key].split(" ")[0]
+                            const collectionIdString = bagContainerContent[key].split(" ")[0];
                             // check if collectionIdString is already in, if it isn't push it
                             if (!collectionIdArray.includes(collectionIdString)) {
                                 collectionIdArray.push(collectionIdString);
@@ -1299,9 +1297,9 @@ const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
                         } 
                     }   
                 }
-            }
+            } 
+        }
         return collectionIdArray;
-        } 
     } catch (error) {
         throw new Error("getBiospecimenCollectionIdsFromBox() error.", {cause: error});
     }


### PR DESCRIPTION
Related Links:
[Phase 2 Enhancements](https://github.com/episphere/connect/issues/708) 
[Issue#548](https://github.com/episphere/biospecimen/issues/548)
[Related biospecimen PR#586](https://github.com/episphere/biospecimen/pull/586)
[Related connectFaas PR#431](https://github.com/episphere/connectFaas/pull/431) 

This PR addresses the 500 status code returned on BPTL's packages in transit

The following code changes were done:
- moved return `collectionIdArray` in getBiospecimenCollectionIdsFromBox function outside of `for (let key in shipBoxObj) {...}` block
- fixed incorrect concept id reference to `orphanScan` variable (was incorrectly referencing biohazardMouthwashBagScan)

Images:
**Status code: 500**
![Screenshot 2023-09-26 at 12 04 16 PM](https://github.com/episphere/connectFaas/assets/33293205/2416ab92-b1c6-46b2-b57a-76c65fe1dc28)

**Local Tests**
![Screenshot 2023-09-26 at 12 03 25 PM](https://github.com/episphere/connectFaas/assets/33293205/ce5a49c5-82de-40de-beb6-b07d6b36e7cc)
