### PR TITLE
Add NORC incentives for Chicago participants

### DIFF
--- a/utils/validation.js
+++ b/utils/validation.js
@@ -308,12 +308,11 @@ const checkDerivedVariables = async (token, siteCode) => {
         anyRefusalWithdrawal = checkRefusalWithdrawals(data);
     }
 
-
     if(incentiveEligible) {
 
         const incentiveUpdates = {
             '130371375.266600170.731498909': 353358909,
-            '130371375.266600170.222373868': data['827220437'] === 809703864 ? 104430631 : 353358909,
+            '130371375.266600170.222373868': 353358909,
             '130371375.266600170.787567527': new Date().toISOString()
         };
 


### PR DESCRIPTION
This PR is related to the following links:

Issue: 
- https://github.com/episphere/connect/issues/740

PR related: 
- https://github.com/episphere/biospecimen/pull/599

---
Issue#740 

Problem: 
- University of Chicago Participants are currently excluded from 'NORC Incentive Eligible' at baseline.

Solution: 
- Removed logic where uChicago participants are excluded from NORC payment eligibility

---

Code Changes: 

- Removed ternary operator logic that checked if data object's Healthcare Provider(827220437) was University of Chicago (80970386) and assigns No (104430631) value to incentiveUpdates's `130371375.266600170.222373868` key
- `130371375.266600170.222373868` key value will now be assigned Yes (353358909), regardless of Healthcare Provider