### PR TITLE
fix misc tube csv mapping

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2257,16 +2257,16 @@ const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTime
                 
                 let conceptTube;
                 if (miscTubeIdSet.has(tubeId)) {
-                    const tubeKey = Object.keys(specimenData).find(tubeKey => tubeConceptIds.includes(tubeKey) && specimenData[tubeKey][fieldMapping.objectId] === element);
-                    conceptTube = tubeKeyToNum[tubeKey];
+                    conceptTube = Object.keys(specimenData).find(tubeKey => tubeConceptIds.includes(tubeKey) && specimenData[tubeKey][fieldMapping.objectId] === element);
                 } else {
                     conceptTube = collectionIdConversion[tubeId]; 
                 }
 
-                const conceptIdTubes = `${conceptTube}.926457119`
-                updateObject[conceptIdTubes] = dateTimeStamp;
+                if (conceptTube) {
+                    const conceptIdTubes = `${conceptTube}.926457119`
+                    updateObject[conceptIdTubes] = dateTimeStamp;
+                }
             }
-
             await db.collection("biospecimen").doc(docId).update(updateObject);
         }
         catch(error){

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2255,11 +2255,9 @@ const processReceiptData = async (collectionIdHolder, collectionIdKeys, dateTime
                 //grab tube ids & map them to appropriate concept ids. If it's a misc tube (0050-0054), find tube's location in specimen to get the concept id.
                 const tubeId = element.split(' ')[1];
                 
-                let conceptTube;
+                let conceptTube = collectionIdConversion[tubeId]; 
                 if (miscTubeIdSet.has(tubeId)) {
                     conceptTube = Object.keys(specimenData).find(tubeKey => tubeConceptIds.includes(tubeKey) && specimenData[tubeKey][fieldMapping.objectId] === element);
-                } else {
-                    conceptTube = collectionIdConversion[tubeId]; 
                 }
 
                 if (conceptTube) {


### PR DESCRIPTION
Fix error in tube to conceptId mapping on shipment receipt.

This function updates the received status of tubes.

We added support for misc tubes 0050-0054, but there was a bug in the mapping. Previously, I mapped them to tubeID (0001-0024).

This update maps to conceptId so the function can update received status based on that conceptId.

This function impacts the receipted csv, since that operation pulls tubes based on each tube's received status and timestamp.