### PR TITLE
Add University of Chicago Incentive Eligible Participants to appear for NORC

### DIFF
--- a/utils/incentive.js
+++ b/utils/incentive.js
@@ -148,9 +148,6 @@ const eligibleForIncentive = async (req, res) => {
 
     const {isParent, siteCodes} = await isParentEntity(authorized);
     
-    if(Array.isArray(siteCodes) && siteCodes.indexOf(809703864) !== -1) {
-        siteCodes.splice(siteCodes.indexOf(809703864), 1) // remove UoC from Sites list
-    }
     
     const { retrieveParticipantsEligibleForIncentives } = require('./firestore');
     const data = await retrieveParticipantsEligibleForIncentives(siteCodes, round, isParent, limit, page);


### PR DESCRIPTION
This PR is related to the following links:

Issues: 
- https://github.com/episphere/connectFaas/pull/439
- https://github.com/episphere/connect/issues/806

---
Issue#740 

Problem: When NORC used the [Get Participants Eligible for Incentive API Endpoint](https://documenter.getpostman.com/view/7490604/SVYnT26j#783e2fea-a8f8-4887-90e2-1b0c62e2fae5) to get University of Chicago incentive eligible participants, one of the two test participants should have appeared.

Solution: 

Removed conditional removing University of Chicago concept Id from `sitesCodes` array. 

---

Code Changes: 

Removed conditional removing University of Chicago concept Id (809703864) from `sitesCodes` array. In the `retrieveParticipantsEligibleForIncentives` function University of Chicago is now added to the sites that can be queried. 