### PR TITLE
[#828] Move sendgrid data to notifications collection

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2855,8 +2855,8 @@ const processEventWebhook = async (event) => {
     console.log(event);
 
     const response = await db
-        .collection("sendgridTracking")
-        .where("sg_message_id", "==", event.sg_message_id)
+        .collection("notifications")
+        .where("id", "==", event.notification_id)
         .get();
 
     if (response.size > 0) {
@@ -2870,27 +2870,11 @@ const processEventWebhook = async (event) => {
                 eventRecord[`${event.event}_reason`] = event.reason;
             }
             await db
-                .collection("sendgridTracking")
+                .collection("notifications")
                 .doc(doc.id)
                 .update(eventRecord);
         }
-    } else {
-        const eventRecord = {
-            [`${event.event}_status`]: true,
-            [`${event.event}_date`]: date,
-            [`${event.event}_timestamp`]: event.timestamp,
-            connect_id: event.connect_id,
-            email: event.email,
-            notification_id: event.notification_id,
-            sg_event_id: event.sg_event_id,
-            sg_message_id: event.sg_message_id,
-            token: event.token,
-        };
-        if (["bounce", "dropped"].includes(event.event)) {
-            eventRecord[`${event.event}_reason`] = event.reason;
-        }
-        await db.collection("sendgridTracking").add(eventRecord);
-    }
+    } 
 };
 
 module.exports = {

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -237,8 +237,6 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
         to: fetchedData[emailField],
         substitutions,
         custom_args: {
-          connect_id: fetchedData.Connect_ID,
-          token: fetchedData.token,
           notification_id,
           gcloud_project: process.env.GCLOUD_PROJECT
         },

--- a/utils/sendGridEventWebhook.js
+++ b/utils/sendGridEventWebhook.js
@@ -1,39 +1,55 @@
 const sgMail = require("@sendgrid/mail");
 const { SecretManagerServiceClient } = require("@google-cloud/secret-manager");
 const { EventWebhook, EventWebhookHeader } = require("@sendgrid/eventwebhook");
+const uuid = require('uuid')
+const admin = require('firebase-admin');
+const db = admin.firestore();
 const { processEventWebhook } = require("./firestore");
 const { getResponseJSON } = require("./shared");
+
+
+const _getSecrets = async (envName) => {
+    const client = new SecretManagerServiceClient();
+    const [version] = await client.accessSecretVersion({
+        name: envName
+    });
+    return version.payload.data.toString();
+};
 
 const _testSendEmail = async (res) => {
     console.log("Start sending email");
 
     try {
-        // Add SendGrid apiKey to test
-        sgMail.setApiKey("");
+        const notificationRecord = {
+            notificationSpecificationsID: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+            id: uuid(),
+            notificationType: 'email',
+            email: '', // Update your data to test
+            notification: {
+              title: 'Test SendGrid Event Webhook',
+              body: '<p>Hello World!</p>',
+              time: new Date().toISOString(),
+            },
+            attempt: '3rd contact',
+            category: 'sendgrid',
+            token: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+            uid: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            read: false,
+          };
+          await db.collection("notifications").add(notificationRecord)
 
-        // Update data to test
+        const apiKey = await _getSecrets(process.env.GCLOUD_SENDGRID_SECRET);
+        sgMail.setApiKey(apiKey);
+
         const msg = {
             personalizations: [
                 {
-                    to: "",
+                    to: notificationRecord.email,
                     custom_args: {
-                        connect_id: "cnid1",
-                        token: "tk1",
-                        notification_id: "nid1",
+                        notification_id: notificationRecord.id,
                         gcloud_project: process.env.GCLOUD_PROJECT,
-                        attempt: "1",
                     },
                 },
-                // {
-                //     to: "",
-                //     custom_args: {
-                //         connect_id: "cnid2",
-                //         token: "tk2",
-                //         notification_id: "nid2",
-                //         gcloud_project: process.env.GCLOUD_PROJECT,
-                //         attempt: "1",
-                //     },
-                // },
             ],
             from: {
                 name:
@@ -43,14 +59,14 @@ const _testSendEmail = async (res) => {
                     process.env.SG_FROM_EMAIL ||
                     "donotreply@myconnect.cancer.gov",
             },
-            subject: "Test SendGrid Event Webhook",
+            subject: notificationRecord.notification.title,
             content: [
                 {
                     type: "text/html",
-                    value: "<p>Hello World!</p>",
+                    value: notificationRecord.notification.body,
                 },
             ],
-            categories: ["Test"],
+            categories: [notificationRecord.category],
         };
         await sgMail.send(msg);
         console.log("Complete sending email");
@@ -74,14 +90,6 @@ const _receivedEvents = async (req, res) => {
     }
 };
 
-const _getSecrets = async () => {
-    const client = new SecretManagerServiceClient();
-    const [version] = await client.accessSecretVersion({
-        name: process.env.GCLOUD_SENDGRID_EVENT_WEBHOOKSECRET,
-    });
-    return version.payload.data.toString();
-};
-
 const sendGridEventWebhook = async (req, res) => {
     try {
         if (req.method !== "POST") {
@@ -94,7 +102,7 @@ const sendGridEventWebhook = async (req, res) => {
         if (query.api === "send") {
             await _testSendEmail(res);
         } else if (query.api === "receive") {
-            const publicKey = await _getSecrets();
+            const publicKey = await _getSecrets(process.env.GCLOUD_SENDGRID_EVENT_WEBHOOKSECRET);
             const eventWebhook = new EventWebhook();
             const ecPublicKey = eventWebhook.convertPublicKeyToECDSA(publicKey);
             const payload = req.rawBody;


### PR DESCRIPTION
This PR addresses issue https://github.com/episphere/connect/issues/828

The data in `notifications` collection will be as image below 

![image](https://github.com/episphere/connectFaas/assets/24559107/4237f5d5-7fdb-44b7-8c0c-aed55cccdf64)
