### PR TITLE
BPTL Dashboard: Update eligible participants query for home collection  (November Stage Update)

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2063,11 +2063,11 @@ const queryTotalAddressesToPrint = async () => {
         const snapShot = await db.collection('participants')
         .where('747006172', '==', 104430631) // withdraw consent
         .where('987563196', '==', 104430631) // deceased
-       //.where('827220437', '==', 125001209) // KPCO
+        .where('827220437', '==', 125001209) // KPCO
         .where('685002411.277479354', '==', 104430631) // mouthwash refusal
         .where('173836415.266600170.156605577', '==', 353358909) // Blood or Urine Collected
-        .where('173836415.266600170.740582332', '>=', '2023-10-01T00:00:00.000Z') // Date/timestamp for Blood or Urine Collected
-        .orderBy('173836415.266600170.740582332', 'desc')
+        .where('173836415.266600170.740582332', '>=', '2023-12-01T00:00:00.000Z') // Date/timestamp for Blood or Urine Collected
+        .orderBy('173836415.266600170.740582332', 'asc') // starts from oldest date to newest date
         .get();
         return snapShot.docs.map(document => processParticipantData(document.data(), true));
     } catch (error) {


### PR DESCRIPTION
Title^^
https://github.com/episphere/connect/issues/771
Query update:
- KPCO site only
- Date of clinical blood or urine collection from 12/1/2023
- Sort order of the list should be starting with 12/1/2023 and then later (i.e. oldest to newest)

Note: Update required only for stage & prod