### PR TITLE
deceased data

### DIFF
--- a/updateParticipantData.json
+++ b/updateParticipantData.json
@@ -509,7 +509,7 @@
         "maxLength": 25
     },
     "892050548": {
-        "dataType": "zip",
+        "dataType": "zipCode",
         "mustExist": false,
         "maxLength": 5
     }

--- a/updateParticipantData.json
+++ b/updateParticipantData.json
@@ -407,5 +407,110 @@
 	"173836415.266600170.110349197": {
 		"dataType": "array",
 		"mustExist": false
-	}
+	},
+	"857217152": {
+        "dataType": "number",
+        "mustExist": false,
+        "values": [104430631, 353358909],
+        "required": true
+    },
+    "772354119": {
+        "dataType": "ISO",
+        "mustExist": false,
+        "required": true
+    },
+	"388711124": {
+        "dataType": "phone",
+        "mustExist": false
+    },
+    "438643922": {
+        "dataType": "phone",
+        "mustExist": false
+    },
+    "793072415": {
+        "dataType": "phone",
+        "mustExist": false
+    },
+    "271757434": {
+        "dataType": "number",
+        "mustExist": false,
+        "values": [104430631, 353358909]
+    },
+    "187894482": {
+        "dataType": "number",
+        "mustExist": false,
+        "values": [104430631, 353358909]
+    },
+    "983278853": {
+        "dataType": "number",
+        "mustExist": false,
+        "values": [104430631, 353358909]
+    },
+    "646873644": {
+        "dataType": "number",
+        "mustExist": false,
+        "values": [104430631, 353358909]
+    },
+    "869588347": {
+        "dataType": "email",
+        "mustExist": false
+    },
+    "849786503": {
+        "dataType": "email",
+        "mustExist": false
+    },
+    "635101039": {
+        "dataType": "email",
+        "mustExist": false
+    },
+    "399159511": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "153211406": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "231676651": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "996038075": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "506826178": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 5
+    },
+    "521824358": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "442166669": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "703385619": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 100
+    },
+    "634434746": {
+        "dataType": "string",
+        "mustExist": false,
+        "maxLength": 25
+    },
+    "892050548": {
+        "dataType": "zip",
+        "mustExist": false,
+        "maxLength": 5
+    }
 }

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -201,7 +201,7 @@ module.exports = {
     // Primary cancer site IDs. participant profile -> occurrences {object} (637153953) -> primary site of cancer (740819233). Null until participant diagnosed with cancer.
     cancerOccurrence: 637153953,
     primaryCancerSite: 740819233,
-    cancerSitesMap: {
+    cancerSites: {
         anal: 939782495,
         bladder: 135725957,
         brain: 518416174,

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -167,4 +167,66 @@ module.exports = {
      collectionDateTimeStamp: 678166505,
      collectionCardFlag: 137401245,
      collectionAddtnlNotes: 260133861,
+
+     // participant deceased data
+    participantDeceased: 857217152,
+    participantDeceasedNORC: 987563196,
+    participantDeceasedTimestamp: 772354119,
+
+    // participant profile
+    firstName: 399159511,
+    preferredName: 153211406,
+    middleName: 231676651,
+    lastName: 996038075,
+    suffix: 506826178,
+    homePhone: 438643922,
+    cellPhone: 388711124,
+    otherPhone: 793072415,
+    prefEmail: 869588347,
+    additionalEmail1: 849786503,
+    additionalEmail2: 635101039,
+    address1: 521824358,
+    address2: 442166669,
+    city: 703385619,    
+    state: 634434746,
+    zip: 892050548,
+    canWeVoicemailMobile: 271757434,
+    canWeVoicemailHome: 187894482,
+    canWeVoicemailOther: 983278853,
+    canWeText: 646873644,
+    userProfileHistory: 569151507,
+    userProfileHistoryTimestamp: 371303487,
+    profileChangeRequestedBy: 611005658,
+
+    // Primary cancer site IDs. participant profile -> occurrences {object} (637153953) -> primary site of cancer (740819233). Null until participant diagnosed with cancer.
+    cancerOccurrence: 637153953,
+    primaryCancerSite: 740819233,
+    cancerSitesMap: {
+        anal: 939782495,
+        bladder: 135725957,
+        brain: 518416174,
+        breast: 847945207,
+        cervical: 283025574,
+        colon: 942970912, // Colon/Rectal
+        espohageal: 596122041,
+        headAndNeck: 489400183, // Head and neck (Including cancers of the mouth, sinuses, nose, or throat. Not including brain or skin cancers)
+        kidney: 863246236,
+        leukemia: 607793249, // Leukemia (blood and bone marrow)
+        liver: 532172400,
+        lung: 754745617, // Lung or Bronchial
+        nonHodgkinsLymphoma: 665036297, // Non-Hodgkin's Lymphoma
+        lymphoma: 200837530, // Lymphoma
+        skinMelanoma: 990319383, // Melanoma (skin)
+        skinNonMelanoma: 487917585, // Non-melanoma skin (basal or squamous)
+        ovarian: 603181162,
+        pancreatic: 482225200,
+        prostate: 295976386,
+        stomach: 764891959,
+        testicular: 248374037,
+        thyroid: 139822395,
+        uterine: 723614811,
+        other: 807835037,
+        unavailableUnknown: 178420302,
+        anotherTypeOfCancer: 868006655,
+    },
 };

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1217,11 +1217,11 @@ const updateQueryListFields = (dataObj, existingDocData) => {
                 if (dataObj[field]) {
                     currentQueryArray = updateQueryArray(dataObj[field], existingDocData?.[field], currentQueryArray);
                 }
-
-                if (currentQueryArray.length > 0) {
-                    updatedQueryObj[queryField] = currentQueryArray;
-                }
             });
+
+            if (currentQueryArray.length > 0) {
+                updatedQueryObj[queryField] = currentQueryArray;
+            }
         }
     }
 
@@ -1238,20 +1238,22 @@ const updateQueryListFields = (dataObj, existingDocData) => {
  * @returns {array<string>} - the updated queryArray.
  */
 const updateQueryArray = (newData, oldData, queryArray) => {
+    let updatedQueryArray = [...queryArray];
+
     newData = typeof newData === 'string' ? newData.toLowerCase() : '';
     oldData = oldData && typeof oldData === 'string' ? oldData.toLowerCase() : '';
 
-    const oldDataIndex = oldData ? queryArray.indexOf(oldData) : -1;
+    const oldDataIndex = oldData ? updatedQueryArray.indexOf(oldData) : -1;
     if (oldDataIndex !== -1) {
-        queryArray.splice(oldDataIndex, 1);
+        updatedQueryArray.splice(oldDataIndex, 1);
     }
 
-    if (!queryArray.includes(newData)) {
-        queryArray.push(newData);
+    if (!updatedQueryArray.includes(newData)) {
+        updatedQueryArray.push(newData);
     }
 
-    return queryArray;
-}
+    return updatedQueryArray;
+};
 
 /**
  * If any of the fields in userProfileHistoryKeys are in dataObj, update the userProfileHistory object in the participant profile.

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1156,6 +1156,135 @@ const buildStreckPlaceholderData = (collectionId, streckTubeData) => {
     console.error(`Issue found in updateSpecimen() (ConnectFaas): Streck Tube not found in biospecimenData for collection Id ${collectionId}. Building placeholder data.`);
 }
 
+const validIso8601Format = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
+const validEmailFormat = /^[a-zA-Z0-9.!#$%&'*+"\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,63}$/;
+const validPhoneFormat = /^\d{10}$/;
+
+const queryListFields = {
+    firstName: [fieldMapping.firstName, fieldMapping.preferredName],
+    lastName: [fieldMapping.lastName],
+    allPhoneNo: [fieldMapping.homePhone, fieldMapping.cellPhone, fieldMapping.otherPhone],
+    allEmails: [fieldMapping.prefEmail, fieldMapping.additionalEmail1, fieldMapping.additionalEmail2],
+}
+
+const userProfileHistoryKeys = [
+    fieldMapping.firstName,
+    fieldMapping.middleName,
+    fieldMapping.lastName,
+    fieldMapping.suffix,
+    fieldMapping.preferredName,
+    fieldMapping.cellPhone,
+    fieldMapping.canWeVoicemailMobile,
+    fieldMapping.canWeText,
+    fieldMapping.homePhone,
+    fieldMapping.canWeVoicemailHome,
+    fieldMapping.otherPhone,
+    fieldMapping.canWeVoicemailOther,
+    fieldMapping.address1,
+    fieldMapping.address2,
+    fieldMapping.city,
+    fieldMapping.state,
+    fieldMapping.zip,
+  ];
+
+
+/**
+ * Check whether dataObj contains any of the fields in participantQueryListFields. If yes, handle the query list fields in the participant profile.
+ * @param {object} dataObj - the update object for the participant profile.
+ * @returns - true if any of the fields in participantQueryListFields are in dataObj. false otherwise.
+ */
+const checkForQueryFields = (dataObj) => {
+    for (const key in queryListFields) {
+        // Check if any field in the array for this key exists in dataObj
+        const hasQueryField = queryListFields[key].some(field => dataObj[field] !== undefined);
+        if (hasQueryField) {
+            return true;
+        }
+    }
+    return false; 
+}
+
+const updateQueryListFields = (dataObj, existingDocData) => {
+    let updatedQueryObj = existingDocData['query'] ? {...existingDocData['query']} : {};
+
+    for (const queryField in queryListFields) {
+        const isFieldPresentInDataObj = queryListFields[queryField].some(field => dataObj[field]);
+        
+        if (isFieldPresentInDataObj) {
+            let currentQueryArray = updatedQueryObj?.[queryField] ? [...updatedQueryObj[queryField]] : [];
+            
+            queryListFields[queryField].forEach(field => {
+                if (dataObj[field]) {
+                    currentQueryArray = updateQueryArray(dataObj[field], existingDocData?.[field], currentQueryArray);
+                }
+
+                if (currentQueryArray.length > 0) {
+                    updatedQueryObj[queryField] = currentQueryArray;
+                }
+            });
+        }
+    }
+
+    return updatedQueryObj;
+}
+
+/**
+ * Name, Phone number, and email updates require special handling because the query.firstName, query.lastName, query.allEmails, and query.allPhoneNo arrays are used for participant search.
+ * These can not be directly updated in the API call. We need to derive them just like we do in SMDB & PWA.
+ * If oldData is present, remove it from the queryArray and replace with newData. If oldData is not present, add newData to the queryArray.
+ * @param {string} newData - the updated query data point.
+ * @param {string} oldData - the existing query data point.
+ * @param {array<string>} queryArray - the array of existing data (query.firstName, query.lastName, query.allPhoneNo, or query.allEmails in the participant record).
+ * @returns {array<string>} - the updated queryArray.
+ */
+const updateQueryArray = (newData, oldData, queryArray) => {
+    newData = typeof newData === 'string' ? newData.toLowerCase() : '';
+    oldData = oldData && typeof oldData === 'string' ? oldData.toLowerCase() : '';
+
+    const oldDataIndex = oldData ? queryArray.indexOf(oldData) : -1;
+    if (oldDataIndex !== -1) {
+        queryArray.splice(oldDataIndex, 1);
+    }
+
+    if (!queryArray.includes(newData)) {
+        queryArray.push(newData);
+    }
+
+    return queryArray;
+}
+
+/**
+ * If any of the fields in userProfileHistoryKeys are in dataObj, update the userProfileHistory object in the participant profile.
+ * @param {object} dataObj - the incoming user profile data object. This is a partial object with update data only, not the complete profile.
+ * @param {object} existingDocData - the existing user profile data object from firestore.
+ * @param {array<string>} siteCodes - the site codes for the user profile update.
+ * userProfileHistory is an array of objects. Each object has a timestamp and a set of fields that were updated.
+ */
+const updateUserProfileHistory = (dataObj, existingDocData, siteCodes) => {
+    const userProfileHistory = existingDocData[fieldMapping.userProfileHistory] ? [...existingDocData[fieldMapping.userProfileHistory]] : [];
+
+    // This data is always added to the update object.
+    let updateObject = {
+        [fieldMapping.userProfileHistoryTimestamp]: new Date().toISOString(),
+        [fieldMapping.profileChangeRequestedBy]: `Site ${siteCodes.toString()}: updateParticipantData API`
+    };
+
+    // If any of the fields in userProfileHistoryKeys are in dataObj, add the existing fields from existingDocData to the updateObject.
+    for (const key of userProfileHistoryKeys) {
+        if (dataObj[key] && existingDocData[key] && dataObj[key] !== existingDocData[key]) {
+            updateObject[key] = existingDocData[key];
+        }
+    }
+
+    // If the updateObject has more than just the timestamp and profileChangeRequestedBy fields, add it to the userProfileHistory array. Else discard.
+    if (Object.keys(updateObject).length > 2) {
+        userProfileHistory.push(updateObject);
+    }
+
+    return userProfileHistory;
+}
+
+
 module.exports = {
     getResponseJSON,
     setHeaders,
@@ -1204,4 +1333,12 @@ module.exports = {
     manageSpecimenBoxedStatusRemoveBag,
     sortBoxOnBagRemoval,
     buildStreckPlaceholderData,
+    validIso8601Format,
+    validEmailFormat,
+    validPhoneFormat,
+    queryListFields,
+    userProfileHistoryKeys,
+    checkForQueryFields,
+    updateQueryListFields,
+    updateUserProfileHistory,
 };

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1261,7 +1261,7 @@ const updateQueryArray = (newData, oldData, queryArray) => {
  * userProfileHistory is an array of objects. Each object has a timestamp and a set of fields that were updated.
  */
 const updateUserProfileHistory = (dataObj, existingDocData, siteCodes) => {
-    const userProfileHistory = existingDocData[fieldMapping.userProfileHistory] ? [...existingDocData[fieldMapping.userProfileHistory]] : [];
+    const userProfileHistory = existingDocData[fieldMapping.userProfileHistory] || [];
 
     // This data is always added to the update object.
     let updateObject = {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -172,6 +172,10 @@ const siteNotificationsHandler = async (Connect_ID, concept, siteCode, obj) => {
 }
 
 const updateParticipantData = async (req, res, authObj) => {
+    const { getParticipantData, updateParticipantData } = require('./firestore');
+    const { checkForQueryFields, initializeTimestamps, userProfileHistoryKeys } = require('./shared');
+    const { checkDerivedVariables } = require('./validation');
+
     logIPAdddress(req);
     setHeaders(res);
     
@@ -220,7 +224,6 @@ const updateParticipantData = async (req, res, authObj) => {
         } 
 
         const participantToken = dataObj.token;
-        const { getParticipantData } = require('./firestore');
         const record = await getParticipantData(participantToken, siteCodes, isParent);
 
         if(!record) {
@@ -291,8 +294,6 @@ const updateParticipantData = async (req, res, authObj) => {
             }
         }
 
-        const { initializeTimestamps } = require('./shared')
-
         for(let key in updatedData) {
             if(initializeTimestamps[key]) {
                 if(initializeTimestamps[key].value && initializeTimestamps[key].value === updatedData[key]) {
@@ -301,28 +302,73 @@ const updateParticipantData = async (req, res, authObj) => {
             }
         }
 
-        if(updatedData['399159511']) updatedData[`query.firstName`] = dataObj['399159511'].toLowerCase();
-        if(updatedData['996038075']) updatedData[`query.lastName`] = dataObj['996038075'].toLowerCase();
+        // Handle deceased data. participantDeceased === yes && participantDeceasedTimestamp req'd. Derive participantDeceasedNORC === fieldMapping.yes.
+        // Ignore and delete deceased data if participantDeceased === no. Return error for incomplete submission.
+        if (updatedData[fieldMapping.participantDeceased] === fieldMapping.yes && updatedData[fieldMapping.participantDeceasedTimestamp]) {
+            updatedData[fieldMapping.participantDeceasedNORC] = fieldMapping.yes;
+        } else if (updatedData[fieldMapping.participantDeceased] === fieldMapping.no) {
+            delete updatedData[fieldMapping.participantDeceased];
+            delete updatedData[fieldMapping.participantDeceasedTimestamp];
+        } else if (updatedData[fieldMapping.participantDeceased] || updatedData[fieldMapping.participantDeceasedTimestamp]) {
+            error = true;
+            responseArray.push({
+                "Invalid Request": {
+                    "Token": participantToken,
+                    "Errors": "Invalid participant deceased data. Deceased variable 857217152 and deceased timestamp 772354119 must be provided together. " +
+                    "Example: {'857217152': 353358909, '772354119': '2023-12-01T00:00:00.000Z'}. Omit 'no' values."
+                }
+            });
+            continue;
+        }
+
+        // Note: Query fields can't be updated directly, they are derived.
+        if (dataObj['query']) {
+            error = true;
+                responseArray.push({'Invalid Request': {'Token': participantToken, 'Errors': 'Query variables cannot be directly updated through this API. The expected values will be derived automatically.'}});
+                continue;
+        }
+
+        // Handle updates to query.firstName, query.lastName, query.allPhoneNo, and query.allEmails arrays (these are used for participant search). Derive and add the updated query array to flatDataObj.
+        const shouldUpdateQueryFields = checkForQueryFields(dataObj);
+        if (shouldUpdateQueryFields) {
+            const { updateQueryListFields } = require('./shared');
+            if (!updatedData['query']) updatedData['query'] = {};
+            updatedData['query'] = updateQueryListFields(dataObj, docData);
+        }
+
+        // Handle updates to user profile history. userProfileHistory is an array of objects. Each object has a timestamp and a userProfile object.
+        const shouldUpdateUserProfileHistory = userProfileHistoryKeys.some(key => key in updatedData);
+        if (shouldUpdateUserProfileHistory) {
+            const { updateUserProfileHistory } = require('./shared');
+            updatedData[fieldMapping.userProfileHistory] = updateUserProfileHistory(dataObj, docData, siteCodes);
+        }
 
         console.log("UPDATED DATA");
         console.log(updatedData);
 
-        if(Object.keys(updatedData).length > 0) {
-
-            const { updateParticipantData } = require('./firestore');
-            const { checkDerivedVariables } = require('./validation');
-
-            await updateParticipantData(docID, updatedData);
-            await checkDerivedVariables(participantToken, docData['827220437']);
-        } 
-
-        responseArray.push({'Success': {'Token': participantToken, 'Errors': 'None'}});
+        try {
+            if(Object.keys(updatedData).length > 0) {
+                await Promise.all([
+                    updateParticipantData(docID, updatedData),
+                    checkDerivedVariables(participantToken, docData['827220437']),
+                ]);
+            }
+            
+            responseArray.push({'Success': {'Token': participantToken, 'Errors': 'None'}});
+        } catch (error) {
+            // Alert the user about the error for this participant but continue to process the rest of the participants.
+            console.error(error);
+            error = true;
+            responseArray.push({'Server Error': {'Token': participantToken, 'Errors': `Please retry this participant. Error: ${error}`}});
+            continue;
+        }
     }
 
     return res.status(error ? 206 : 200).json({code: error ? 206 : 200, results: responseArray});
 }
 
 const qc = (newData, existingData, rules) => {
+    const { validPhoneFormat, validEmailFormat } = require('./shared');
     let errors = [];
     for(key in newData) {
         if(key == 'token') continue;
@@ -337,7 +383,22 @@ const qc = (newData, existingData, rules) => {
             if(rules[key].dataType) {
                 if(rules[key].dataType === 'ISO') {
                     if(typeof newData[key] !== "string" || !(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(newData[key]))) {
-                        errors.push(" Invalid data type / format for Key (" + key + ")");
+                        errors.push(`Data mismatch: ${key} must be ISO 8601 string. Example: '2023-12-15T12:45:52.123Z'` );
+                    }
+                }
+                else if (rules[key].dataType === 'phone') {
+                    if (typeof newData[key] !== 'string' || !validPhoneFormat.test(newData[key])) {
+                        errors.push(`Data mismatch: ${key} must be a phone number. 10 character string, no spaces, no dashes. Example: '1234567890'`);
+                    }
+                }
+                else if (rules[key].dataType === 'email') {
+                    if (typeof newData[key] !== 'string' || !validEmailFormat.test(newData[key])) {
+                        errors.push(`Data mismatch: ${key} must be an email address. Example: abc@xyz.com`);
+                    }
+                }
+                else if (rules[key].dataType === 'zip') {
+                    if (typeof newData[key] !== 'string' || newData[key].length !== 5) {
+                        errors.push(`Data mismatch: ${key} zip code must be a 5 character string. Example: '12345'`);
                     }
                 }
                 else if(rules[key].dataType === 'array') {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -343,11 +343,9 @@ const updateParticipantData = async (req, res, authObj) => {
             updatedData[fieldMapping.userProfileHistory] = updateUserProfileHistory(dataObj, docData, siteCodes);
         }
 
-        console.log("UPDATED DATA");
-        console.log(updatedData);
 
         try {
-            if(Object.keys(updatedData).length > 0) {
+            if (Object.keys(updatedData).length > 0) {
                 await Promise.all([
                     updateParticipantData(docID, updatedData),
                     checkDerivedVariables(participantToken, docData['827220437']),
@@ -355,11 +353,11 @@ const updateParticipantData = async (req, res, authObj) => {
             }
             
             responseArray.push({'Success': {'Token': participantToken, 'Errors': 'None'}});
-        } catch (error) {
+        } catch (e) {
             // Alert the user about the error for this participant but continue to process the rest of the participants.
-            console.error(error);
+            console.error(e);
             error = true;
-            responseArray.push({'Server Error': {'Token': participantToken, 'Errors': `Please retry this participant. Error: ${error}`}});
+            responseArray.push({'Server Error': {'Token': participantToken, 'Errors': `Please retry this participant. Error: ${e}`}});
             continue;
         }
     }

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -324,7 +324,7 @@ const updateParticipantData = async (req, res, authObj) => {
         // Note: Query fields can't be updated directly, they are derived.
         if (dataObj['query']) {
             error = true;
-                responseArray.push({'Invalid Request': {'Token': participantToken, 'Errors': 'Query variables cannot be directly updated through this API. The expected values will be derived automatically.'}});
+            responseArray.push({'Invalid Request': {'Token': participantToken, 'Errors': 'Query variables cannot be directly updated through this API. The expected values will be derived automatically.'}});
                 continue;
         }
 
@@ -355,7 +355,7 @@ const updateParticipantData = async (req, res, authObj) => {
             responseArray.push({'Success': {'Token': participantToken, 'Errors': 'None'}});
         } catch (e) {
             // Alert the user about the error for this participant but continue to process the rest of the participants.
-            console.error(e);
+            console.error(`Server error updating participant at updateParticipantData & checkDerivedVariables. ${e}`);
             error = true;
             responseArray.push({'Server Error': {'Token': participantToken, 'Errors': `Please retry this participant. Error: ${e}`}});
             continue;
@@ -394,7 +394,7 @@ const qc = (newData, existingData, rules) => {
                         errors.push(`Data mismatch: ${key} must be an email address. Example: abc@xyz.com`);
                     }
                 }
-                else if (rules[key].dataType === 'zip') {
+                else if (rules[key].dataType === 'zipCode') {
                     if (typeof newData[key] !== 'string' || newData[key].length !== 5) {
                         errors.push(`Data mismatch: ${key} zip code must be a 5 character string. Example: '12345'`);
                     }


### PR DESCRIPTION
Issue: https://github.com/episphere/connect/issues/823

Update the updateParticipantData API for:

(1) deceased data: 2 new data points + one derived data point per issue 823.
Note: the deceased data is currently ignored if submitted and deceased = no.
 
(2) user profile archiving: This API needs to handle user profile archiving the same way ConnectApp and SMDB handle archiving.

(3) participant profile query arrays handling: Similarly, we need to handle the participant 'query' arrays (first name, last name phone, email) the same way it's handled in SMDB and ConnectApp to ensure consistent participant search functionality across our apps (Biospecimen & SMDB search functions).

