### PR TITLE
update BPTL specimen package receipt processing

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -885,17 +885,43 @@ const biospecimenAPIs = async (req, res) => {
         }
 
     // Store Receipt POST- BPTL 
-    else if(api === 'storeReceipt') {
-            if(req.method !== 'POST') {
-                return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
-            }
-            let requestData = req.body;
-            if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+    else if (api === 'storeSpecimenReceipt') {
+        if(req.method !== 'POST') {
+            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+        }
+
+        const requestData = req.body;
+        
+        if (!requestData || Object.keys(requestData).length === 0) {
+            return res.status(400).json(getResponseJSON('Request body is empty!', 400));
+        }
+        
+        try {
             const { storePackageReceipt } = require('./firestore');
             const response = await storePackageReceipt(requestData);
-            if(!response) return res.status(404).json(getResponseJSON('ERROR!', 404));
-            return res.status(200).json({message: `Success!`, code:200});
+
+            if (!response) {
+                return res.status(404).json(getResponseJSON('ERROR!', 404));
+            } else if (response.message === 'Box Not Found') {
+                return res.status(404).json(getResponseJSON(response.message, 404));
+            } else if (response.message === 'Multiple Results' || response.message === 'Box Already Received') {
+                return res.status(409).json({ message: response.message, data: response.data, code: 409 });
+            } else {
+                return res.status(200).json(getResponseJSON(response.message, 200));
+            }
+        } catch (error) {
+            console.error('Error storing package receipt:', error);
+            if (error.message.includes('setPackageReceiptFedex')) {
+                return res.status(500).json(getResponseJSON(`FedEx processing error. ${error.message}`, 500));
+            } else if (error.message.includes('setPackageReceiptUSPS')) {
+                return res.status(500).json(getResponseJSON(`USPS processing error. ${error.message}`, 500));
+            } else if (error.message.includes('processReceiptData')) {
+                return res.status(500).json(getResponseJSON(`Data processing error. ${error.message}`, 500));
+            } else {
+                return res.status(500).json(getResponseJSON(`Internal server error. ${error.message}`, 500));
+            }
         }
+    }
 
     // BPTL Metrics GET- BPTL 
     else  if(api === 'bptlMetrics') {

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -21,6 +21,7 @@ module.exports = {
     submitShipmentFlag: 145971562,
     siteShipmentReceived: 333524031,
     submitShipmentTimestamp: 656548982,
+    shipmentReceivedTimestamp: 926457119,
     shippingBoxId: 132929440,
     shipmentCourier: 666553960,
     shipperEmail: 948887825,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2537,8 +2537,6 @@ const setPackageReceiptFedex = async (boxUpdateData) => {
         const boxDocRef = boxListData[0].boxDocRef;
         const boxData = boxListData[0].boxData;
 
-        console.log('boxUpdateData: ', boxUpdateData);
-
         // snapshotReceivedTimestamp should be null. If not null, box has already been received.
         // Handle box already received and forceWriteOverride property. This has happened by mistake in production.
         const snapshotReceivedTimestamp = boxData[fieldMapping.shipmentReceivedTimestamp];
@@ -2622,7 +2620,7 @@ const processReceiptData = async (collectionIdHolder, boxUpdateData, boxDocRef) 
                     updateObject[conceptIdTubes] = receivedTimestamp;
                 }
             }
-            console.log(collectionIdHolder[key], 'updateObject', updateObject);
+            
             batch.update(specimenDocRef, updateObject);
         }
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1156,6 +1156,8 @@ const buildStreckPlaceholderData = (collectionId, streckTubeData) => {
     console.error(`Issue found in updateSpecimen() (ConnectFaas): Streck Tube not found in biospecimenData for collection Id ${collectionId}. Building placeholder data.`);
 }
 
+const validIso8601Format = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
+
 module.exports = {
     getResponseJSON,
     setHeaders,
@@ -1204,4 +1206,5 @@ module.exports = {
     manageSpecimenBoxedStatusRemoveBag,
     sortBoxOnBagRemoval,
     buildStreckPlaceholderData,
+    validIso8601Format,
 };

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -915,7 +915,7 @@ const processSpecimenCollections = (specimenCollections, receivedTimestamp) => {
             specimenDataArray.push({
                 'specimens': filteredSpecimens,
                 '820476880': specimenCollection['data']['820476880'],
-                '926457119': specimenCollection['data']['926457119'],
+                '926457119': receivedTimestamp, // Tube-level (not specimen-level) data required for this field. They can be different values.
                 '678166505': specimenCollection['data']['678166505'],
                 '827220437': specimenCollection['data']['827220437'],
                 '951355211': specimenCollection['data']['951355211'],


### PR DESCRIPTION
Update the `storeReceipt` endpoint along with `setPackageReceiptFedex()`

**Important:** merge concurrently with https://github.com/episphere/biospecimen/pull/633

Related Issues:
Missing tube timestamps: https://github.com/episphere/connect/issues/819 & https://github.com/episphere/connect/issues/653
Duplicate tracking number: https://github.com/episphere/connect/issues/834

Related PRs:
https://github.com/episphere/biospecimen/pull/633

-add communication with BPTL user when unusual package receipt situations arise (duplicate tracking numbers & already received packages).
-batch process box and specimen receipt to ensure database consistency (solve missing tube timestamps issue).
-update error handling so we have a better trace if issues persist.
-change endpoint name to storeSpecimenReceipt to differentiate from other newly added functionality.