### PR TITLE
Get Specimen and Participant

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -226,6 +226,22 @@ const biospecimenAPIs = async (req, res) => {
 
         return res.status(200).json({message: 'Success!', code:200});
     }
+    else if (api === 'getSpecimenAndParticipant') {
+        if (req.method !== 'GET') return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        if (!req.query.collectionId) return res.status(400).json(getResponseJSON('Collection ID is missing.', 400));
+
+        const collectionId = req.query.collectionId;
+        const isBPTL = req.query.isBPTL === 'true';
+
+        try {
+            const { getSpecimenAndParticipant } = require('./firestore');
+            const { specimenData, participantData } = await getSpecimenAndParticipant(collectionId, siteCode, isBPTL);
+            return res.status(200).json({ data: [specimenData, participantData], message: 'Success!', code: 200 });
+        } catch (error) {
+            console.error(`Error in getSpecimenAndParticipant(). ${error.message}`);
+            return res.status(500).json({ data: [], message: `Error in getSpecimenAndParticipant(). ${error}`, code: 500 });
+        }
+    }
     else if (api === 'searchSpecimen') {
         if(req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -239,7 +239,7 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(200).json({ data: [specimenData, participantData], message: 'Success!', code: 200 });
         } catch (error) {
             console.error(`Error in getSpecimenAndParticipant(). ${error.message}`);
-            return res.status(500).json({ data: [], message: `Error in getSpecimenAndParticipant(). ${error}`, code: 500 });
+            return res.status(500).json({ data: [], message: `Error in getSpecimenAndParticipant(). ${error.message}`, code: 500 });
         }
     }
     else if (api === 'searchSpecimen') {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1319,6 +1319,40 @@ const reportMissingSpecimen = async (siteAcronym, requestData) => {
 
 }
 
+/**
+ * Collection ID editing uses the specimen collection doc and the participant doc when an unfinalized collection's tube details are edited.
+ * @param {string} collectionId - the collectionId of the specimen to retrieve.
+ * @param {string} siteCode - Site code of the site that collected the specimen.
+ * @param {boolean} isBPTL - Is this a BPTL call? If yes, don't apply the healthCareProvider filter.
+ * @returns {object, object} - the specimenCollection and the attached participant. Used in Biospecimen Collection editing screen from Collection ID search.
+ */
+const getSpecimenAndParticipant = async (collectionId, siteCode, isBPTL) => {
+    try {
+        // Fetch the specimen
+        let query = db.collection('biospecimen').where(fieldMapping.collectionId.toString(), '==', collectionId);
+        if (!isBPTL) query = query.where(fieldMapping.healthCareProvider.toString(), '==', siteCode);
+        const specimenSnapshot = await query.get();
+
+        if (specimenSnapshot.size !== 1) {
+            throw new Error('Couldn\'t find matching specimen document.');
+        }
+        const specimenData = specimenSnapshot.docs[0].data();
+
+        // Use the Connect_ID in the specimen doc to fetch the participant
+        const participantSnapshot = await db.collection('participants').where('Connect_ID', '==', specimenData['Connect_ID']).get();
+
+        if (participantSnapshot.size !== 1) {
+            throw new Error('Couldn\'t find matching participant document.');
+        }
+        const participantData = participantSnapshot.docs[0].data();
+
+        return { specimenData, participantData };
+    } catch (error) {
+        console.error(error);
+        throw new Error(`Error in getSpecimenAndParticipant(). ${error}`, { cause: error });
+    }
+}
+
 const searchSpecimen = async (masterSpecimenId, siteCode, allSitesFlag) => {
     const snapshot = await db.collection('biospecimen').where('820476880', '==', masterSpecimenId).get();
     if (snapshot.size === 1) {
@@ -3084,5 +3118,6 @@ module.exports = {
     addKitStatusToParticipant,
     eligibleParticipantsForKitAssignment,
     processEventWebhook,
+    getSpecimenAndParticipant,
     queryKitsByReceivedDate
 }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1348,8 +1348,7 @@ const getSpecimenAndParticipant = async (collectionId, siteCode, isBPTL) => {
 
         return { specimenData, participantData };
     } catch (error) {
-        console.error(error);
-        throw new Error(`Error in getSpecimenAndParticipant(). ${error}`, { cause: error });
+        throw new Error(error, { cause: error });
     }
 }
 


### PR DESCRIPTION
Add getSpecimenAndParticipant endpoint

Related issue: https://github.com/episphere/connect/issues/833

Related PR:
Note: Merge with Biospecimen PR

-Return specimen and participant data in one operation instead of separate calls.
-Used in collection ID search -> collection data entry form.
-Continued migration away from `searchSpecimen()` catch-all endpoint.
