### PR TITLE
new requirement: death data -> update participation status to deceased

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -169,7 +169,7 @@ module.exports = {
      collectionCardFlag: 137401245,
      collectionAddtnlNotes: 260133861,
 
-     // participant deceased data
+     // EMR participant deceased data
     participantDeceased: 857217152,
     participantDeceasedNORC: 987563196,
     participantDeceasedTimestamp: 772354119,
@@ -198,6 +198,8 @@ module.exports = {
     userProfileHistory: 569151507,
     userProfileHistoryTimestamp: 371303487,
     profileChangeRequestedBy: 611005658,
+    participationStatus: 912301837,
+    participationStatusDeceased: 618686157,
 
     // cancer occurrences
     occurrenceNumber: 793981056,

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -295,6 +295,7 @@ const updateParticipantData = async (req, res, authObj) => {
         // Ignore and delete deceased data if participantDeceased === no. There is no error case (data already validated).
         if (flatUpdateObj[fieldMapping.participantDeceased] === fieldMapping.yes) {
             flatUpdateObj[fieldMapping.participantDeceasedNORC] = fieldMapping.yes;
+            flatUpdateObj[fieldMapping.participationStatus] = fieldMapping.participationStatusDeceased;
         } else if (flatUpdateObj[fieldMapping.participantDeceased] === fieldMapping.no) {
             delete flatUpdateObj[fieldMapping.participantDeceased];
             delete flatUpdateObj[fieldMapping.participantDeceasedTimestamp];


### PR DESCRIPTION
Issue: https://github.com/episphere/connect/issues/856

New death data requirement:
Add participation status -> deceased to EMR death data update via updateParticipantData API.

This update sets 912301837 (participation status) to the value 618686157 (deceased) when EMR death data is sent through the updateParticipantData API.