### PR TITLE
SiteManger Dashboard: Update token reference in HP’s self-scheduling link email (Part 2)

### DIFF
--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -171,7 +171,7 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
   htmlTemplate = htmlTemplate.replace("<firstName>", "{{firstName}}");
   if (htmlTemplate.includes("${token}")) {
     htmlContainsToken = true;
-    htmlTemplate = htmlTemplate.replace("${token}", "{{token}}");
+    htmlTemplate = htmlTemplate.replaceAll("${token}", "{{token}}");
   }
 
   if (htmlTemplate.includes("<loginDetails>")) {
@@ -229,7 +229,7 @@ async function getParticipantsAndSendEmails({notificationSpec, cutoffTimeStr, ti
 
       if (htmlContainsToken) {
         substitutions.token = fetchedData.token;
-        notificationBody = notificationBody.replace("{{token}}", fetchedData.token);
+        notificationBody = notificationBody.replaceAll("{{token}}", fetchedData.token);
       }
 
       const notification_id = uuid();


### PR DESCRIPTION

This PR addresses following issue comment:
https://github.com/episphere/connect/issues/846#issuecomment-1864990185

Function `getParticipantsAndSendEmails()` is only picking up the first TOKEN sign & not the rest. To prevent this, use `replaceAll()` instead `replace` to update multiple references to TOKEN.

`replaceAll()` works for single TOKEN reference as well.

PoC: https://replit.com/@Ajonnada/Nodejs#index.js