### PR TITLE
[#640] Delete related data of new tables after running data destruction

### DIFF
--- a/utils/shared.js
+++ b/utils/shared.js
@@ -280,6 +280,8 @@ const listOfCollectionsRelatedToDataDestruction = [
     "module4_v1",
     "biospecimen",
     "notifications",
+    "cancerOccurrence",
+    "kitAssembly"
 ];
 
 const incentiveConcepts = {


### PR DESCRIPTION
This PR addresses comment of PR https://github.com/episphere/connect/issues/640#issuecomment-1896266558

- Remove all related data of participant that has been destroyed data in 2 tables kitAssembly, cancerOccurrence