### PR TITLE
more restrictive timestamp validation

### DIFF
--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1322,7 +1322,7 @@ const buildStreckPlaceholderData = (collectionId, streckTubeData) => {
     console.error(`Issue found in updateSpecimen() (ConnectFaas): Streck Tube not found in biospecimenData for collection Id ${collectionId}. Building placeholder data.`);
 }
 
-const validIso8601Format = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
+const validIso8601Format = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const validEmailFormat = /^[a-zA-Z0-9.!#$%&'*+"\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,63}$/;
 const validPhoneFormat = /^\d{10}$/;
 


### PR DESCRIPTION
Tighten up existing timestamp validation to match length.

Vijay found the long-running validation had a flaw:

Previous RegExp: const validIso8601Format = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
The expected date format: 2023-11-07T18:58:38.901Z
But this was passing the check when it should have been failing: 2022233-01-10T09:44:00.033Z

The new version enforces start and end (overall length).