### PR TITLE
updateParticipantData array validation

### DIFF
--- a/updateParticipantData.json
+++ b/updateParticipantData.json
@@ -402,11 +402,13 @@
 	},
 	"173836415.266600170.543608829": {
 		"dataType": "array",
-		"mustExist": false
+		"mustExist": false,
+		"innerElementType": "string"
 	},
 	"173836415.266600170.110349197": {
 		"dataType": "array",
-		"mustExist": false
+		"mustExist": false,
+		"innerElementType": "string"
 	},
 	"857217152": {
         "dataType": "number",

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1139,9 +1139,16 @@ const flattenObject = (obj, parentPath = '') => {
 
             if (value && typeof value === 'object') {
                 if (Array.isArray(value)) {
-                    value.forEach((item, index) => {
-                        traverse(item, `${newPath}[${index}]`);
-                    });
+                    // Check if element is an object to decide whether to traverse further. 
+                    // This ensures arrays of primitive values are kept intact. 
+                    // Seen in keys 173836415.266600170.110349197 & 173836415.266600170.543608829.
+                    if (value.length === 0 || typeof value[0] !== 'object') {
+                        flattened[newPath] = value;
+                    } else {
+                        value.forEach((item, index) => {
+                            traverse(item, `${newPath}[${index}]`);
+                        });
+                    }
                 } else {
                     traverse(value, newPath);
                 }
@@ -1475,6 +1482,7 @@ const filterSelectedFields = (dataObjArray, selectedFieldsArray) => {
         return filteredData;
     });
 }
+
 
 
 module.exports = {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -436,6 +436,13 @@ const validateUpdateParticipantData = (value, existingValue, path, rule) => {
             if (!Array.isArray(value)) {
                 return `Data mismatch: ${path} must be an array.`;
             }
+            if (rule.innerElementType) {
+                for (let i = 0; i < value.length; i++) {
+                    if (typeof value[i] !== rule.innerElementType) {
+                        return `Data mismatch: Element at index ${i} of ${path} must be a ${rule.innerElementType}.`;
+                    }
+                }
+            }
             break;
         case 'object':
             if (typeof value !== 'object' || Array.isArray(value)) {


### PR DESCRIPTION
hotfix: Gitter issue - Array validation for variables
173836415.266600170.110349197 and
173836415.266600170.543608829

I wasn't aware of these arrays when updating validation methods in updateParticipantData API.