### PR TITLE
biospecimen reports

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1436,6 +1436,7 @@ const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
  * query the biospecimen collection for documents that match the healthcare provider and collectionIds in collectionIdArray
  * @param {number} requestedSite - site code of the site 
  * @param {string} boxId - boxId of the box
+ * @returns {array} - array of biospecimen documents
  * Firestore 'in' operator limit with two .where() clauses is 15 (30 with one .where() clause).
 */
 const searchSpecimenBySiteAndBoxId = async (requestedSite, boxId) => {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1436,21 +1436,30 @@ const getBiospecimenCollectionIdsFromBox = async (requestedSite, boxId) => {
  * query the biospecimen collection for documents that match the healthcare provider and collectionIds in collectionIdArray
  * @param {number} requestedSite - site code of the site 
  * @param {string} boxId - boxId of the box
+ * Firestore 'in' operator limit with two .where() clauses is 15 (30 with one .where() clause).
 */
-//TODO: extend to batch query for > 15 items in collectionIdArray
 const searchSpecimenBySiteAndBoxId = async (requestedSite, boxId) => {
     try {
         const collectionIdArray = await getBiospecimenCollectionIdsFromBox(requestedSite, boxId);
-        const snapshot = await db.collection('biospecimen')
-                                .where(fieldMapping.healthCareProvider.toString(), "==", requestedSite)
-                                .where(fieldMapping.collectionId.toString(), "in", collectionIdArray).get();
+
+        const chunkSize = 15;
+        const collectionIdArrayChunks = createChunkArray(collectionIdArray, chunkSize);
+        
+        const chunkedPromises = collectionIdArrayChunks.map(chunk => {
+            return db.collection('biospecimen')
+            .where(fieldMapping.healthCareProvider.toString(), "==", requestedSite)
+            .where(fieldMapping.collectionId.toString(), "in", chunk).get();
+        });
+        
+        const promiseResults = await Promise.all(chunkedPromises);
+        
         const biospecimenDocs = [];
+        promiseResults.forEach(snapshot => {
+            if (!snapshot.empty) {
+                snapshot.docs.forEach(doc => biospecimenDocs.push(doc.data()));
+            }
+        });
 
-        if (snapshot.empty) return biospecimenDocs;
-
-        for (let document of snapshot.docs) {
-            biospecimenDocs.push(document.data());
-        }
         return biospecimenDocs;
     } catch (error) {
         throw new Error("searchSpecimenBySiteAndBoxId() error.", {cause: error});
@@ -1750,9 +1759,8 @@ const getNumBoxesShipped = async (siteCode, body) => {
     try {
         let query = db.collection('boxes').where('145971562', '==', 353358909);
         query = preQueryBuilder(filters, query, trackingId, endDate, startDate, source, siteCode);
-        const snapshot = await query.get();
-        const result = snapshot.docs.length;
-        return result;
+        const snapshot = await query.count().get();
+        return snapshot.data().count;
     } catch (error) {
         console.error(error);
         return new Error(error)


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/755

Optimize reports data
• update searchSpecimenBySiteAndBoxId to handle more collectionIDs (for new big shipping boxes)
• use snapshot.count().get() for reports pagination. This counts docs and returns an integer instead of pulling all data and counting the length. Cost = 1 read per 1000 docs instead of 1 read per doc, data usage drastically reduced.

This merges with: https://github.com/episphere/biospecimen/pull/663