### PR TITLE
PROMIS Survey Updates (API)

### DIFF
--- a/utils/events.js
+++ b/utils/events.js
@@ -2,7 +2,7 @@ const firestore = require('@google-cloud/firestore');
 const {BigQuery} = require('@google-cloud/bigquery');
 const {Storage} = require('@google-cloud/storage');
 
-const collectionNameArray = ['participants', 'biospecimen', 'boxes', 'module1_v1', 'module1_v2', 'module2_v1', 'module2_v2', 'module3_v1', 'module4_v1', 'bioSurvey_v1', 'menstrualSurvey_v1', 'clinicalBioSurvey_v1', 'covid19Survey_v1', 'kitAssembly', 'mouthwash_v1', 'sendgridTracking', 'cancerOccurrence'];
+const collectionNameArray = ['participants', 'biospecimen', 'boxes', 'module1_v1', 'module1_v2', 'module2_v1', 'module2_v2', 'module3_v1', 'module4_v1', 'bioSurvey_v1', 'menstrualSurvey_v1', 'clinicalBioSurvey_v1', 'covid19Survey_v1', 'kitAssembly', 'mouthwash_v1', 'sendgridTracking', 'cancerOccurrence', 'promis_v1'];
 
 const firestoreExport = async (eventData, context) => {
   await exportCollectionsToBucket(collectionNameArray);

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -251,5 +251,11 @@ module.exports = {
     ssnPartialGiven: 914639140,
     ssnPartialGivenTime: 598680838,
     ssnQcStatus: 605870562,
-    ssnNoCheckRan: 875207881
+    ssnNoCheckRan: 875207881,
+
+    // Survey Status Variables
+    notYetEligible: 789467219,
+    notStarted:     972455046,
+    started:        615768760,
+    submitted:      231311385 
 };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3057,6 +3057,27 @@ const updateParticipantCorrection = async (participantData) => {
     }
 }
 
+const updateSurveyEligibility = async (token, survey) => {
+
+    try {
+        const snapshot = await db.collection('participants').where('token', '==', token).get();
+        
+        if (snapshot.empty) return;
+
+        const data = snapshot.docs[0].data()
+
+        if (data[survey] === fieldMapping.notYetEligible) {
+            const docId = snapshot.docs[0].id;
+            const updates = {[survey]: fieldMapping.notStarted}
+        
+            await db.collection('participants').doc(docId).update(updates);
+        }
+    } catch (error) {
+        throw new Error("Error updating survey eligibility.", { cause: error });
+    }
+}
+
+
 module.exports = {
     updateResponse,
     retrieveParticipants,
@@ -3177,5 +3198,6 @@ module.exports = {
     queryKitsByReceivedDate,
     getParticipantCancerOccurrences,
     writeCancerOccurrences,
-    updateParticipantCorrection
+    updateParticipantCorrection,
+    updateSurveyEligibility
 }

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -407,8 +407,8 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
 
 
     
-    if ((emailRecordArray[0] && emailRecordArray[0].category === 'PROMIS' && emailRecordArray[0].attempt === '1st Contact') ||
-        (smsRecordArray[0] && smsRecordArray[0].category === 'PROMIS' && smsRecordArray[0].attempt === '1st Contact')) { //placeholders
+    if ((emailRecordArray[0] && emailRecordArray[0].category === '3mo QOL Survey Reminders' && emailRecordArray[0].attempt === '1st Contact') ||
+        (smsRecordArray[0] && smsRecordArray[0].category === '3mo QOL Survey Reminders' && smsRecordArray[0].attempt === '1st Contact')) {
 
       const { moduleStatusConcepts, findKeyByValue } = require('./shared');
       const surveyStatus = findKeyByValue(moduleStatusConcepts, 'promis');

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -405,6 +405,30 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
       smsCount += smsRecordArray.length;
     }
 
+
+    
+    if ((emailRecordArray[0] && emailRecordArray[0].category === 'PROMIS' && emailRecordArray[0].attempt === '1st Contact') ||
+        (smsRecordArray[0] && smsRecordArray[0].category === 'PROMIS' && smsRecordArray[0].attempt === '1st Contact')) { //placeholders
+
+      const { moduleStatusConcepts, findKeyByValue } = require('./shared');
+      const surveyStatus = findKeyByValue(moduleStatusConcepts, 'promis');
+  
+      for (let participant of [...emailRecordArray, ...smsRecordArray]) {
+
+        const token = participant.token;
+
+        try {
+          const { updateSurveyEligibility } = require('./firestore');
+          await updateSurveyEligibility(token, surveyStatus);
+        }
+        catch (error) {
+          console.error(`Error updating survey eligibility for token ${token}`, error);
+          break;
+        }
+      }
+    }
+    
+
     try {
       await saveNotificationBatch([...emailRecordArray, ...smsRecordArray]);
     } catch (error) {

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -3,9 +3,10 @@ const sgMail = require("@sendgrid/mail");
 const showdown = require("showdown");
 const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
 const {getResponseJSON, setHeadersDomainRestricted, setHeaders, logIPAdddress, redactEmailLoginInfo, redactPhoneLoginInfo, createChunkArray, validEmailFormat} = require("./shared");
-const {getScheduledNotifications, saveNotificationBatch} = require("./firestore");
+const {getScheduledNotifications, saveNotificationBatch, updateSurveyEligibility} = require("./firestore");
 const {getParticipantsForNotificationsBQ} = require("./bigquery");
 const conceptIds = require("./fieldToConceptIdMapping");
+
 let twilioClient, messagingServiceSid;
 
 (async () => {
@@ -407,8 +408,8 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
 
 
     
-    if ((emailRecordArray[0] && emailRecordArray[0].category === '3mo QOL Survey Reminders' && emailRecordArray[0].attempt === '1st Contact') ||
-        (smsRecordArray[0] && smsRecordArray[0].category === '3mo QOL Survey Reminders' && smsRecordArray[0].attempt === '1st Contact')) {
+    if ((emailRecordArray[0] && emailRecordArray[0].category === '3mo QOL Survey Reminders' && emailRecordArray[0].attempt === '1st contact') ||
+        (smsRecordArray[0] && smsRecordArray[0].category === '3mo QOL Survey Reminders' && smsRecordArray[0].attempt === '1st contact')) {
 
       const { moduleStatusConcepts, findKeyByValue } = require('./shared');
       const surveyStatus = findKeyByValue(moduleStatusConcepts, 'promis');
@@ -418,7 +419,6 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
         const token = participant.token;
 
         try {
-          const { updateSurveyEligibility } = require('./firestore');
           await updateSurveyEligibility(token, surveyStatus);
         }
         catch (error) {

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -217,6 +217,7 @@ const defaultFlags = {
     663265240: 972455046,
     265193023: 972455046,
     220186468: 972455046,
+    320303124: 972455046,
     459098666: 972455046,
     126331570: 972455046,
     311580100: 104430631,
@@ -247,7 +248,8 @@ const moduleConceptsToCollections = {
     "D_912367929" :     "menstrualSurvey_v1",
     "D_826163434" :     "clinicalBioSurvey_v1",
     "D_166676176" :     "ssn",
-    "D_390351864" :     "mouthwash_v1"
+    "D_390351864" :     "mouthwash_v1",
+    "D_601305072" :     "promis_v1"
 }
 
 const moduleStatusConcepts = {
@@ -260,7 +262,8 @@ const moduleStatusConcepts = {
     "459098666" :       "menstrualSurvey",
     "253883960" :       "clinicalBioSurvey",
     "126331570" :       "ssn",
-    "547363263" :       "mouthwash"
+    "547363263" :       "mouthwash",
+    "320303124" :       "promis"
 }
 
 const listOfCollectionsRelatedToDataDestruction = [
@@ -276,6 +279,7 @@ const listOfCollectionsRelatedToDataDestruction = [
     "module4_v1",
     "biospecimen",
     "notifications",
+    "promis_v1"
 ];
 
 const incentiveConcepts = {

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -217,7 +217,7 @@ const defaultFlags = {
     663265240: 972455046,
     265193023: 972455046,
     220186468: 972455046,
-    320303124: 972455046,
+    320303124: 789467219,
     459098666: 972455046,
     126331570: 972455046,
     311580100: 104430631,
@@ -814,6 +814,11 @@ const isEmpty = (object) => {
 
     return true;
 }
+
+const findKeyByValue = (object, value) => {
+    return Object.keys(object).find(key => object[key] === value);
+}
+
 
 const isDateTimeFormat = (value) => {
     return typeof value == "string" && (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(value));
@@ -1516,6 +1521,7 @@ module.exports = {
     batchLimit,
     getUserProfile,
     isEmpty,
+    findKeyByValue,
     isDateTimeFormat,
     createChunkArray,
     redactEmailLoginInfo,


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/877
-----
## Background Details
* With the new PROMIS QOL Survey being added to the study we need to add logic into the API to accept responses from this survey and store them appropriately. We also need to mark participants as eligible for this survey once they first get an email or text 
-----
## Technical Changes
* Added PROMIS collection to list of Firestore collections to be backed up in `events.js`
* Added module status Concept IDs to `fieldToConceptIdMapping.js`
* Added function `updateSurveyEligiblity()` to mark a participant's status on a survey from `Not Yet Eligible` to `Not Yet Started`
* Added default variable for PROMIS Module Status to `shared.js`
* Added value for PROMIS survey to `moduleConceptsToCollections`, `listOfCollectionsRelatedToDataDestruction` and `moduleStatusConcepts` in `shared.js`
* Added utility function `findKeyByValue` to `shared.js`
* Added logic in `notifications.js` to call `updateSurveyEligiblity()` when participant receives first PROMIS SMS or Email notification
 