### PR TITLE
fetch sha (commit history) for survey data

### DIFF
--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -74,7 +74,6 @@ const connectApp = async (req, res) => {
       return res.status(200).json({data: shaResult, code: 200});
     }
     else if (api === 'getSHAFromGitHubCommitData') {
-      console.log('called getSHAFromGitHubCommitData endpoint');
       if (req.method !== 'GET') {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
       }
@@ -86,8 +85,8 @@ const connectApp = async (req, res) => {
       const surveyStartTimestamp = req.query.surveyStartTimestamp || '';
       const path = req.query.path;
 
-      const { getShaFromGitHubCommitData } = require('./submission');
-      const shaResult = await getShaFromGitHubCommitData(surveyStartTimestamp, path);
+      const { getSHAFromGitHubCommitData } = require('./submission');
+      const shaResult = await getSHAFromGitHubCommitData(surveyStartTimestamp, path);
       
       return res.status(200).json({data: shaResult, code: 200});
     }

--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -73,6 +73,24 @@ const connectApp = async (req, res) => {
       
       return res.status(200).json({data: shaResult, code: 200});
     }
+    else if (api === 'getSHAFromGitHubCommitData') {
+      console.log('called getSHAFromGitHubCommitData endpoint');
+      if (req.method !== 'GET') {
+        return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+      }
+
+      if (!req.query.path || req.query.path === '') {
+        return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
+      }
+
+      const surveyStartTimestamp = req.query.surveyStartTimestamp || '';
+      const path = req.query.path;
+
+      const { getShaFromGitHubCommitData } = require('./submission');
+      const shaResult = await getShaFromGitHubCommitData(surveyStartTimestamp, path);
+      
+      return res.status(200).json({data: shaResult, code: 200});
+    }
 
     else return res.status(400).json(getResponseJSON('Bad request!', 400));
 

--- a/utils/submission.js
+++ b/utils/submission.js
@@ -616,7 +616,7 @@ const getModuleSHA = async (path) => {
  * @param {String} path - the file name of the module in the questionnaire repository.
  * @returns {String} - The SHA of the commit that was active when the survey was started.
  */
-const getShaFromGitHubCommitData = async (surveyStartTimestamp, path) => {
+const getSHAFromGitHubCommitData = async (surveyStartTimestamp, path) => {
     try {
         const { SecretManagerServiceClient } = require('@google-cloud/secret-manager');
         const client = new SecretManagerServiceClient();
@@ -680,5 +680,5 @@ module.exports = {
     getUserSurveys,
     getUserCollections,
     getModuleSHA,
-    getShaFromGitHubCommitData,
+    getSHAFromGitHubCommitData,
 }


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/906

(1) Fetch sha value based on module, commit history, and survey start timestamp. This keeps survey versioning aligned for participants.

(2) update `retrieveUserSurveys` for parallel fetching (performance improvement).

EDIT: (3) Search raw text at the time of commit (based on sha value) to retrieve the correct version number for the module.