### PR TITLE
PROMIS Survey Scoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@sendgrid/eventwebhook": "^8.0.0",
         "@sendgrid/mail": "^8.1.0",
         "crypto": "^1.0.1",
+        "crypto-js": "^4.2.0",
         "fast-crc32c": "^2.0.0",
         "firebase-admin": "^11.11.1",
         "firebase-functions": "^4.5.0",
@@ -1996,6 +1997,11 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/dayjs": {
       "version": "1.11.10",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@sendgrid/eventwebhook": "^8.0.0",
     "@sendgrid/mail": "^8.1.0",
     "crypto": "^1.0.1",
+    "crypto-js": "^4.2.0",
     "fast-crc32c": "^2.0.0",
     "firebase-admin": "^11.11.1",
     "firebase-functions": "^4.5.0",

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,0 +1,486 @@
+const promisConfig = {
+    'Physical Function': {
+        id: '7AA4002D-61C1-438D-9063-91A17FFA68BB',
+        source: 'D_284353934',
+        questions: {
+            'D_559540891': {
+                name: 'PFA11',
+                responses: {
+                    '367964536': 'Without any difficulty',
+                    '193058048': 'With a little difficulty',
+                    '263412634': 'With some difficulty',
+                    '734992634': 'With much difficulty',
+                    '221192556': 'Unable to do'
+                }
+            }, 
+            'D_917425212': {
+                name: 'PFA21',
+                responses: {
+                    '367964536': 'Without any difficulty',
+                    '193058048': 'With a little difficulty',
+                    '263412634': 'With some difficulty',
+                    '734992634': 'With much difficulty',
+                    '221192556': 'Unable to do'
+                }
+            }, 
+            'D_783201540': {
+                name: 'PFA23',
+                responses: {
+                    '367964536': 'Without any difficulty',
+                    '193058048': 'With a little difficulty',
+                    '263412634': 'With some difficulty',
+                    '734992634': 'With much difficulty',
+                    '221192556': 'Unable to do'
+                }
+            }, 
+            'D_780866928': {
+                name: 'PFA53',
+                responses: {
+                    '367964536': 'Without any difficulty',
+                    '193058048': 'With a little difficulty',
+                    '263412634': 'With some difficulty',
+                    '734992634': 'With much difficulty',
+                    '221192556': 'Unable to do'
+                }
+            }
+        },
+        score: 'D_608953994',
+        error: 'D_582985641'
+    },
+    'Anxiety': {
+        id: '6C13662F-179A-45AD-A8DF-16843D902E28',
+        source: 'D_404946076',
+        questions: {
+            'D_429680247': {
+                name: 'EDANX01',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_179665441': {
+                name: 'EDANX40',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_195292223': {
+                name: 'EDANX41',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_829976839': {
+                name: 'EDANX53',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }
+        },
+        score: 'D_328149278',
+        error: 'D_281351288'
+    },
+    'Depression': {
+        id: '597A9B24-5B5C-487D-9606-451355DC6E3D',
+        source: 'D_715048033',
+        questions: {
+            'D_468039454': {
+                name: 'EDDEP04',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_361835532': {
+                name: 'EDDEP06',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_803322918': {
+                name: 'EDDEP29',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_168582270': {
+                name: 'EDDEP41',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '211590917': 'Often',
+                    '907579123': 'Always'
+                }
+            }
+        },
+        score: 'D_328149278',
+        error: 'D_144446277'
+    },
+    'Fatigue': {
+        id: '2E25400B-9373-4631-B769-2E4D466EED04',
+        source: 'D_907490539',
+        questions: {
+            'D_467404576': {
+                name: 'HI7',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_658945347': {
+                name: 'AN3',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_105063268': {
+                name: 'FATEXP41',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_787436735': {
+                name: 'FATEXP40',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }
+        },
+        score: 'D_410751656',
+        error: 'D_101862879'
+    },
+    'Sleep Disturbance': {
+        id: '795B07C1-067E-4FBD-9B60-A57985E69B5D',
+        source: 'D_336566965',
+        questions: {
+            'D_992194402': {
+                name: 'Sleep109',
+                responses: {
+                    '878535894': 'Very poor',
+                    '138752522': 'Poor',
+                    '131550264': 'Fair',
+                    '719933364': 'Good',
+                    '565881164': 'Very good'
+                }
+            }, 
+            'D_624200915': {
+                name: 'Sleep116',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_526006101': {
+                name: 'Sleep20',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_644233792': {
+                name: 'Sleep44',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }
+        },
+        score: 'D_990793746',
+        error: 'D_218828500'
+    },
+    'Social Participation': {
+        id: 'B730F00E-C958-4654-85C1-0931A7289322',
+        source: 'D_420392309',
+        questions: {
+            'D_271090432': {
+                name: 'SRPPER11_CaPS',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_828608766': {
+                name: 'SRPPER18_CaPS',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_886047084': {
+                name: 'SRPPER23_CaPS',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_226478149': {
+                name: 'SRPPER46_CaPS',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }
+        },
+        score: 'D_393186700',
+        error: 'D_801982443',
+    },
+    'Pain Interference': {
+        id: 'A192B2B3-9FB0-40A4-9E95-AF309780C8E0',
+        source: 'D_420560514',
+        questions: {
+            'D_693503159': {
+                name: 'PAININ9',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_754781311': {
+                name: 'PAININ22',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_380975443': {
+                name: 'PAININ31',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_426764225': {
+                name: 'PAININ34',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }
+        },
+        score: 'D_370227545',
+        error: 'D_766974306',
+    },
+    'Social Satisfaction': {
+        id: '2AF69E2C-7571-475B-A5DE-E77AF1DF4A17',
+        source: 'D_261177801',
+        questions: {
+            'D_313287837': {
+                name: 'SRPSAT06r1',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_598001940': {
+                name: 'SPRSAT34r1',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_733106290': {
+                name: 'SRPSAT34r1',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }, 
+            'D_542492755': {
+                name: 'SRPSAT49r1',
+                responses: {
+                    '111520945': 'Not at all',
+                    '548628123': 'A little bit',
+                    '567908725': 'Somewhat',
+                    '760969884': 'Quite a bit',
+                    '464631026': 'Very much'
+                }
+            }
+        },
+        score: 'D_697423629',
+        error: 'D_424548783',
+    },
+    'Social Isolation': {
+        id: 'BE5C09D1-1FB2-474C-B17C-8EC8F98F396D',
+        source: 'D_326712049',
+        questions: {
+            'D_437905191': {
+                name: 'UCLA11x2',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_387564567': {
+                name: 'UCLA13x3',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_479680555': {
+                name: 'UCLA14x2',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }, 
+            'D_311938392': {
+                name: 'UCLA18x2',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely',
+                    '132099255': 'Sometimes',
+                    '734611348': 'Usually',
+                    '907579123': 'Always'
+                }
+            }
+        },
+        score: 'D_129202138',
+        error: 'D_633951291',
+    },
+    'Cognitive Function': {
+        id: 'A0511754-DFB1-4492-81D9-1FC3ED3DD31C',
+        source: 'D_230486322',
+        questions: {
+            'D_960308206': {
+                name: 'PC2r',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely (Once)',
+                    '132099255': 'Sometimes (Two or three times)',
+                    '211590917': 'Often (About once a day)',
+                    '398006869': 'Very often (Several times a day)'
+                }
+            }, 
+            'D_974618086': {
+                name: 'PC35r',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely (Once)',
+                    '132099255': 'Sometimes (Two or three times)',
+                    '211590917': 'Often (About once a day)',
+                    '398006869': 'Very often (Several times a day)'
+                }
+            }, 
+            'D_115480943': {
+                name: 'PC36r',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely (Once)',
+                    '132099255': 'Sometimes (Two or three times)',
+                    '211590917': 'Often (About once a day)',
+                    '398006869': 'Very often (Several times a day)'
+                }
+            }, 
+            'D_650091514': {
+                name: 'PC42r',
+                responses: {
+                    '648960871': 'Never',
+                    '235613392': 'Rarely (Once)',
+                    '132099255': 'Sometimes (Two or three times)',
+                    '211590917': 'Often (About once a day)',
+                    '398006869': 'Very often (Several times a day)'
+                }
+            }
+        },
+        score: 'D_755066850',
+        error: 'D_132343154',
+    }
+}
+
+module.exports = {
+    promisConfig
+}

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1,4 +1,5 @@
-const fieldMapping = require('./fieldToConceptIdMapping')
+const fieldMapping = require('./fieldToConceptIdMapping');
+const CryptoJS = require('crypto-js');
 
 const getResponseJSON = (message, code) => {
     return { message, code };
@@ -1487,6 +1488,15 @@ const filterSelectedFields = (dataObjArray, selectedFieldsArray) => {
     });
 }
 
+const generateAuthToken = () => {
+
+    const uoid = '56BE7A9C-7A46-444C-869E-539B58C6A149';
+    const token = '2C8C3D2F-75D6-4580-8D77-069C8215D64B';
+
+    const encodedWord = CryptoJS.enc.Utf8.parse(uoid + ":" + token);
+    const encoded = CryptoJS.enc.Base64.stringify(encodedWord);
+    return encoded;
+}
 
 module.exports = {
     getResponseJSON,
@@ -1547,4 +1557,5 @@ module.exports = {
     flattenObject,
     handleCancerOccurrences,
     filterSelectedFields,
+    generateAuthToken
 };


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/870
-----
## Background Details
* Now that the PROMIS Survey has been added to the study we need to add logic to return and store scoring results based on the answers given by each participant
-----
## Technical Changes
* Added `crypto-js` library
* Added `promos.js` to store configuration needed for passing results to Scoring API and function needed to generate authorization token
* Added functions to `submission.js` to process PROMIS survey results and call Scoring API