### PR TITLE
[#I828] Sendgrid Data Merge to Notifications Collection Table 

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3013,13 +3013,12 @@ const getSpecimensByCollectionIds = async (collectionIdsArray, siteCode, isBPTL 
 }
 
 const processSendGridEvent = async (event) => {
-    if (event.gcloud_project !== process.env.GCLOUD_PROJECT) return;
+    if (!event.notification_id || event.gcloud_project !== process.env.GCLOUD_PROJECT) return;
 
     const date = new Date(event.timestamp * 1000).toISOString();
-
     const snapshot = await db
-        .collection("sendgridTracking")
-        .where("sgMessageId", "==", event.sg_message_id)
+        .collection("notifications")
+        .where("id", "==", event.notification_id)
         .get();
 
     if (snapshot.size > 0) {
@@ -3032,23 +3031,9 @@ const processSendGridEvent = async (event) => {
         if (["bounce", "dropped"].includes(event.event)) {
             eventRecord[`${event.event}Reason`] = event.reason;
         }
-        await db.collection("sendgridTracking").doc(doc.id).update(eventRecord);
+        await db.collection("notifications").doc(doc.id).update(eventRecord);
     } else {
-        const eventRecord = {
-            [`${event.event}Status`]: true,
-            [`${event.event}Date`]: date,
-            [`${event.event}Timestamp`]: event.timestamp,
-            connectId: event.connect_id,
-            email: event.email,
-            notificationId: event.notification_id,
-            sgEventId: event.sg_event_id,
-            sgMessageId: event.sg_message_id,
-            token: event.token,
-        };
-        if (["bounce", "dropped"].includes(event.event)) {
-            eventRecord[`${event.event}Reason`] = event.reason;
-        }
-        await db.collection("sendgridTracking").add(eventRecord);
+        console.error(`Could not find notifications ${event.notification_id}. Status ${event.event}`)
     }
 };
 

--- a/utils/webhook.js
+++ b/utils/webhook.js
@@ -1,5 +1,5 @@
 const { getResponseJSON } = require("./shared");
-const { processTwilioEvent, processSendGridEvent, processMergingSendGridData } = require("./firestore");
+const { processTwilioEvent, processSendGridEvent } = require("./firestore");
 const { SecretManagerServiceClient } = require("@google-cloud/secret-manager");
 const { EventWebhook, EventWebhookHeader } = require("@sendgrid/eventwebhook");
 
@@ -52,17 +52,6 @@ const handleReceivedSendGridEvent = async (req, res) => {
     }
 };
 
-const mergeSendgridData = async (res) => {
-    try {
-        await processMergingSendGridData();
-        
-        return res.status(200).json({ code: 200 });
-    } catch (e) {
-        console.error(e);
-        return res.status(500).json({ code: 500 });
-    }
-};
-
 const webhook = async (req, res) => {
     if (req.method !== "POST") {
         return res
@@ -79,8 +68,6 @@ const webhook = async (req, res) => {
         return await handleReceivedTwilioEvent(req, res);
     } else if (query.api === "sendgrid-email-status") {
         return await handleReceivedSendGridEvent(req, res);
-    } else if (query.api === "merge-sendgrid-data") {
-        return await mergeSendgridData(res);
     } else return res.status(400).json(getResponseJSON("Bad request!", 400));
 };
 


### PR DESCRIPTION
This PR addresses issue https://github.com/episphere/connect/issues/828

Change:

- Updated function `processSendGridEvent` for updating the sendgrid webhook data to notifications collection instead of sendgridTracking collection
- Created fucntion `processMergingSendGridData` for merging all the old data from sendgridTracking collection into notifications collection

Note:

- After merging all the old data from sendgridTracking collection into notifications collection, we will remove this code and the sendgridTracking collection in firestore as well.