### PR TITLE
Change bio kit mouthwash cid and eligibility date filter

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -817,23 +817,6 @@ const biospecimenAPIs = async (req, res) => {
         }
     }
 
-    else if(api == 'assignKit'){
-        if(req.method !== 'POST') {
-            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
-        }
-        let requestData = req.body;
-        if(Object.keys(requestData).length === 0 ) return res.status(400).json(getResponseJSON('Request body is empty!', 400));
-        try {
-            const { assignKitToParticipant } = require('./firestore');
-            const response = await assignKitToParticipant(requestData);
-            return res.status(200).json({data: response, code:200});
-        }
-        catch {
-            console.error(error);
-            return res.status(500).json(getResponseJSON(error.message, 500));
-        }
-    }
-
     else if(api == 'getKitData'){
         if(req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -167,6 +167,16 @@ module.exports = {
      collectionDateTimeStamp: 678166505,
      collectionCardFlag: 137401245,
      collectionAddtnlNotes: 260133861,
+     collectionDetails: 173836415,
+     baseline: 266600170,
+     bioKitMouthwash: 319972665,
+     withdrawConsent: 747006172,
+     activityParticipantRefusal: 685002411,
+     baselineMouthwashSample: 277479354,
+     bloodOrUrineCollected: 156605577,
+     bloodOrUrineCollectedTimestamp: 740582332,
+     collectionRound: 418571751,
+     mouthwashKit: 976461859,
 
      // EMR participant deceased data
     participantDeceased: 857217152,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2293,6 +2293,11 @@ const processVerifyScannedCode = async (id) => {
 
 const confirmShipmentKit = async (shipmentData) => {
     try {
+        const collectionDetails = fieldMapping.collectionDetails;
+        const baseline = fieldMapping.baseline;
+        const bioKitMouthwash = fieldMapping.bioKitMouthwash;
+        const UKID = fieldMapping.UKID;
+
         const kitSnapshot = await db.collection("kitAssembly").where('687158491', '==', shipmentData['687158491']).get();
 
         if (kitSnapshot.size === 0) {
@@ -2307,7 +2312,7 @@ const confirmShipmentKit = async (shipmentData) => {
 
         await kitDoc.ref.update(kitData);
         const participantSnapshot = await db.collection("participants")
-            .where(`${fieldMapping.collectionDetails}.${fieldMapping.baseline}.${fieldMapping.bioKitMouthwash}.${fieldMapping.UKID}`, '==', shipmentData[fieldMapping.UKID]).get();
+            .where(`${collectionDetails}.${baseline}.${bioKitMouthwash}.${UKID}`, '==', shipmentData[UKID]).get();
 
         if (participantSnapshot.size === 0) {
             return false;
@@ -2315,7 +2320,7 @@ const confirmShipmentKit = async (shipmentData) => {
 
         const participantDoc = participantSnapshot.docs[0];
         const participantDocData = participantDoc.data();
-        const prevParticipantObject = participantDocData[fieldMapping.collectionDetails][fieldMapping.baseline][fieldMapping.bioKitMouthwash];
+        const prevParticipantObject = participantDocData[collectionDetails][baseline][bioKitMouthwash];
         const baselineParticipantObject = participantDocData[173836415][266600170];
         const uid = participantDocData['state']['uid'];
         const Connect_ID = participantDocData['Connect_ID'];


### PR DESCRIPTION
This pull request addresses the following:

- https://github.com/episphere/connect/issues/901
- https://github.com/episphere/connect/issues/911

Problems
- Issue# 901 - Incorrect bio mouthwash kit concept Id used `8583443674`
- Issue#911 - Change time from `01-01-2024` to 04-01-2024

Code Change
- Issue# 901 - Change incorrect concept Id from `8583443674` to correct concept Id `319972665`
- Issue#911 - Change timestamp in  `queryTotalAddressesToPrint` function to `2024-04-01T00:00:00.000Z`

Refactor / Styling:

- Removed extra `else if(api == 'assignKit')` per @anthonypetersen  request- https://github.com/episphere/connect/issues/901#issue-2149135961
- Add to `fieldMapping.js` for conceptId references
- Replaced some hardcoded concept Ids with names that reference fieldMapping for readability

Note: Decided to use assignment destructuring in some cases when declaring variables to reference fieldMapping would cause more lines of code.