### PR TITLE
Fixed PROMIS Scoring CID

### DIFF
--- a/utils/promis.js
+++ b/utils/promis.js
@@ -204,7 +204,7 @@ const promisConfig = {
                 responses: promisResponseSets.responseSet2
             }
         },
-        score: 'D_328149278',
+        score: 'D_297016093',
         error: 'D_144446277'
     },
     'Fatigue': {


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/870
-----
## Background Details
* The wrong Concept ID was used in the configuration file for PROMIS Scoring
-----
## Technical Changes
* Updated constant in `promis.js`