### PR TITLE
Remove getParticipants 'filter' option.

### DIFF
--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -46,6 +46,24 @@ const dashboard = async (req, res) => {
     } else if (api === 'getParticipants') {
         const { getParticipants } = require('./submission');
         return await getParticipants(req, res, authObj);
+    } else if (api === 'getFilteredParticipants') {
+        if (req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        
+        // req.query includes 'api' key plus query params from the participant search form.
+        if(Object.keys(req.query).length < 2) {
+            return res.status(400).json(getResponseJSON('Please include at least one search parameter.', 400));
+        }
+        
+        try {
+            req.query.source = 'dashboard';
+            const { getFilteredParticipants } = require('./submission');
+            return await getFilteredParticipants(req, res, authObj);
+        } catch (error) {
+            console.error('Error in getFilteredParticipants.', error);
+            return res.status(500).json(getResponseJSON('An error occurred while searching for this participant. Please try again later.', 500));
+        }
     } else if (api === 'identifyParticipant' && isParent === false) {
         const { identifyParticipant } = require('./submission');
         return await identifyParticipant(req, res, siteCodes);

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2133,13 +2133,13 @@ const queryTotalAddressesToPrint = async () => {
             collectionDetails, baseline, bloodOrUrineCollected, bloodOrUrineCollectedTimestamp, yes, no } = fieldMapping;
 
         const snapshot = await db.collection('participants')
-        .where(withdrawConsent.toString(), '==', no)
-        .where(participantDeceasedNORC.toString(), '==', no)
-        .where(`${activityParticipantRefusal}.${baselineMouthwashSample}`, '==', no)
-        .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollected}`, '==', yes)
-        .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '>=', '2024-04-01T00:00:00.000Z')
-        .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc')
-        .get();
+            .where(withdrawConsent.toString(), '==', no)
+            .where(participantDeceasedNORC.toString(), '==', no)
+            .where(`${activityParticipantRefusal}.${baselineMouthwashSample}`, '==', no)
+            .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollected}`, '==', yes)
+            .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '>=', '2024-04-01T00:00:00.000Z')
+            .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`)
+            .get();
         return snapshot.docs.map(document => processParticipantData(document.data(), true));
     } catch (error) {
         console.error(error);

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -61,13 +61,6 @@ const lockedAttributes = [
                         
                     ] // Read only access after initialization
 
-const filterData = async (queries, siteCodes, isParent) => {
-    console.log(queries);
-    const { filterDB } = require('./firestore');
-    const result = await filterDB(queries, siteCodes, isParent);
-    return result;
-}
-
 const incentiveFlags = {
     130371375 : { // Payment Round
         266600170: { // Baseline
@@ -1545,7 +1538,6 @@ module.exports = {
     randomString,
     deleteDocuments,
     setHeadersDomainRestricted,
-    filterData,
     incentiveFlags,
     lockedAttributes,
     moduleConceptsToCollections,


### PR DESCRIPTION
Related:
https://github.com/episphere/connect/issues/953
https://github.com/episphere/connect/issues/960

•Make `getParticipants` API `'filter'` option obsolete.
•Point Biospecimen and SMDB participant search at `getFilteredParticipants` API
•rm `filterData` function (no longer used)
•update sort order to ascending in `queryTotalAddressesToPrint` function
