### PR TITLE
update sorting for Home Collections 'Print Labels' and 'Assign Kits'

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -758,8 +758,8 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
         try {
-            const { queryTotalAddressesToPrint } = require('./firestore');
-            const response = await queryTotalAddressesToPrint();
+            const { queryHomeCollectionAddressesToPrint } = require('./firestore');
+            const response = await queryHomeCollectionAddressesToPrint();
             return res.status(200).json({data: response, code:200});
         }
         catch (error) {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -757,12 +757,12 @@ const biospecimenAPIs = async (req, res) => {
         if(req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
+        
         try {
             const { queryHomeCollectionAddressesToPrint } = require('./firestore');
             const response = await queryHomeCollectionAddressesToPrint();
             return res.status(200).json({data: response, code:200});
-        }
-        catch (error) {
+        } catch (error) {
             console.error(error);
             return res.status(500).json(getResponseJSON(error.message, 500));
         }
@@ -806,12 +806,12 @@ const biospecimenAPIs = async (req, res) => {
         if(req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
+        
         try {
             const { eligibleParticipantsForKitAssignment } = require('./firestore');
             const response = await eligibleParticipantsForKitAssignment();
             return res.status(200).json({data: response, code:200});
-        }
-        catch {
+        } catch (error){
             console.error(error);
             return res.status(500).json(getResponseJSON(error.message, 500));
         }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2149,7 +2149,7 @@ const checkCollectionUniqueness = async (supplyId, collectionId) => {
 };
 
 const participantHomeCollectionKitFields = [
-    `${fieldMapping.collectionDetails.toString()}.${fieldMapping.baseline.toString()}`,
+    fieldMapping.collectionDetails.toString(),
     fieldMapping.firstName.toString(),
     fieldMapping.lastName.toString(),
     fieldMapping.address1.toString(),


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/960
 
•Update sorting order for Home Collections 'Assign Kits'
•Use .select() to pull less data
•Update naming conventions
•Add TODOs for future enhancements (this was a late addition, and future enhancements require coordination with the Biospecimen team)
