### PR TITLE
KP Prod Change 051024

### DIFF
--- a/updateParticipantData.json
+++ b/updateParticipantData.json
@@ -549,5 +549,10 @@
 		"dataType": "string",
 		"mustExist": false,
 		"maxLength": 800
+	},
+	"512820379": {
+		"values": [486306141, 854703046],
+		"dataType": "number",
+		"mustExist": false
 	}
 }


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* KP needs to update the Concept ID `512820379` for 562 participants and it was decided the best way to do so was temporarily update the rules for the Update Participant Data API
-----
## Technical Changes
* Added rule to `updateParticipantData.json`