### PR TITLE
temp endpoint

### DIFF
--- a/config/prod/cloudbuild1.yaml
+++ b/config/prod/cloudbuild1.yaml
@@ -7,6 +7,10 @@ steps:
   args: ['functions', 'deploy', 'biospecimen', '--trigger-http', '--runtime=${_RUNTIME}', '--source=${_SOURCE}', '--env-vars-file=config/prod/.env.yaml']
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['functions', 'add-iam-policy-binding', 'biospecimen', '--member=allUsers', '--role=${_ROLE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['functions', 'deploy', 'promis', '--trigger-http', '--runtime=${_RUNTIME}', '--source=${_SOURCE}', '--env-vars-file=config/prod/.env.yaml']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['functions', 'add-iam-policy-binding', 'promis', '--member=allUsers', '--role=${_ROLE}']
 substitutions:
   _SOURCE: https://source.developers.google.com/projects/nih-nci-dceg-connect-prod-6d04/repos/github_episphere_connectfaas
   _RUNTIME: nodejs20

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const { importToBigQuery, firestoreExport, exportNotificationsToBucket, importNo
 const { participantDataCleanup } = require('./utils/participantDataCleanup');
 const { webhook } = require('./utils/webhook');
 
+const { promisBackfill } = require('./utils/firestore');
+
 // API End-Points for Sites
 
 exports.incentiveCompleted = incentiveCompleted;
@@ -69,3 +71,7 @@ exports.participantDataCleanup = participantDataCleanup;
 // End-Points for Event Webhook
 
 exports.webhook = webhook;
+
+
+// Temporary End-Point
+exports.promis = promisBackfill;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3359,12 +3359,16 @@ const promisBackfill = async (req, res) => {
 
     if(req.method === 'OPTIONS') return res.status(200).json({code: 200});
 
-    const snapshot = await db.collection('promis_v1').get();
+    const snapshot = await db.collection('promis_v1').limit(100).get();
 
     snapshot.docs.forEach( doc => {
         const data = doc.data();
         const uid = data['uid'];
-        processPromisResults(uid);
+        
+        if (!data['D_608953994']) {
+            console.log(uid);
+            processPromisResults(uid);
+        }
     });
 
     return res.status(200).json({code: 200});


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* Undiscovered bug when PROMIS survey was released prevented scoring API from being called when participants completed the survey
* Need to manually trigger these results to get processed
* Due to API being behind firewall we need a temporary end-point that can access the API when called from a local source
-----
## Technical Changes
* 