### PR TITLE
Duplicate tracking numbers now prohibited (1038)

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -671,14 +671,14 @@ const biospecimenAPIs = async (req, res) => {
         if( req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
-        const supplyQuery = req.query.supplyKitId;
-        const collectionQuery = (req.query.collectionId?.slice(0, -4) || "") + " " + (req.query.collectionId?.slice(-4) || ""); // add space to collection
-        const returnKitTrackingNumberQuery = req.query.returnKitTrackingNumber;
+        const supplyKitId = req.query.supplyKitId;
+        const collectionIdSuffix = (req.query.collectionId?.slice(0, -4) || "") + " " + (req.query.collectionId?.slice(-4) || ""); // add space to collection
+        const returnKitTrackingNumberNumber = req.query.returnKitTrackingNumber;
         if (Object.keys(query).length === 0) return res.status(404).json(getResponseJSON('Please include id to check uniqueness.', 400));
-        if (collectionQuery.length < 14) return res.status(200).json({data: 'Check Collection ID', code:200});
+        if (collectionIdSuffix.length < 14) return res.status(200).json({data: 'Check Collection ID', code:200});
         try {
             const { checkCollectionUniqueness } = require('./firestore');
-            const response = await checkCollectionUniqueness(supplyQuery, collectionQuery, returnKitTrackingNumberQuery);
+            const response = await checkCollectionUniqueness(supplyKitId, collectionIdSuffix, returnKitTrackingNumberNumber);
             return res.status(200).json({data: response, code:200});
         }
         catch (error) {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -673,11 +673,12 @@ const biospecimenAPIs = async (req, res) => {
         }
         const supplyQuery = req.query.supplyKitId;
         const collectionQuery = (req.query.collectionId?.slice(0, -4) || "") + " " + (req.query.collectionId?.slice(-4) || ""); // add space to collection
+        const returnKitTrackingNumberQuery = req.query.returnKitTrackingNumber;
         if (Object.keys(query).length === 0) return res.status(404).json(getResponseJSON('Please include id to check uniqueness.', 400));
         if (collectionQuery.length < 14) return res.status(200).json({data: 'Check Collection ID', code:200});
         try {
             const { checkCollectionUniqueness } = require('./firestore');
-            const response = await checkCollectionUniqueness(supplyQuery, collectionQuery);
+            const response = await checkCollectionUniqueness(supplyQuery, collectionQuery, returnKitTrackingNumberQuery);
             return res.status(200).json({data: response, code:200});
         }
         catch (error) {

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2327,7 +2327,6 @@ const assignKitToParticipant = async (data) => {
         const otherKitsUsingSupplyKitTrackingNumber = await db.collection("kitAssembly")
             .where(`${supplyKitTrackingNum}`, '==', data[supplyKitTrackingNum])
             .get();
-            // .where(`${supplyKitId}`, '!=', data[supplyKitId]).get();
 
         if(otherKitsUsingSupplyKitTrackingNumber.size > 1) {
                 return false;


### PR DESCRIPTION
Validation work to prevent duplicate tracking numbers, per [1038](https://github.com/episphere/connect/issues/1038). Requires corresponding biospecimen work for full functionality.