### PR TITLE
fetch survey modules through GitHub  API (authenticated)

### DIFF
--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -79,16 +79,15 @@ const connectApp = async (req, res) => {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
       }
 
-      if (!req.query.sha) {
+      const { sha, path } = req.query;
+
+      if (!sha) {
         return res.status(400).json(getResponseJSON('Sha parameter is required!', 400));
       }
 
-      if (!req.query.path) {
+      if (!path) {
         return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
       }
-
-      const sha = req.query.sha;
-      const path = req.query.path;
 
       const { getQuestSurveyFromGitHub } = require('./submission');
       const moduleTextAndVersionResult = await getQuestSurveyFromGitHub(sha, path);

--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -62,7 +62,7 @@ const connectApp = async (req, res) => {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
       }
 
-      if (!req.query.path || req.query.path === '') {
+      if (!req.query.path) {
         return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
       }
 
@@ -79,11 +79,11 @@ const connectApp = async (req, res) => {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
       }
 
-      if (!req.query.sha || req.query.sha === '') {
+      if (!req.query.sha) {
         return res.status(400).json(getResponseJSON('Sha parameter is required!', 400));
       }
 
-      if (!req.query.path || req.query.path === '') {
+      if (!req.query.path) {
         return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
       }
 
@@ -101,7 +101,7 @@ const connectApp = async (req, res) => {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
       }
 
-      if (!req.query.path || req.query.path === '') {
+      if (!req.query.path) {
         return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
       }
 

--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -74,6 +74,28 @@ const connectApp = async (req, res) => {
       return res.status(200).json({data: shaResult, code: 200});
     }
 
+    else if (api === 'getQuestSurveyFromGitHub') {
+      if (req.method !== 'GET') {
+        return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+      }
+
+      if (!req.query.sha || req.query.sha === '') {
+        return res.status(400).json(getResponseJSON('Sha parameter is required!', 400));
+      }
+
+      if (!req.query.path || req.query.path === '') {
+        return res.status(400).json(getResponseJSON('Path parameter is required!', 400));
+      }
+
+      const sha = req.query.sha;
+      const path = req.query.path;
+
+      const { getQuestSurveyFromGitHub } = require('./submission');
+      const moduleTextAndVersionResult = await getQuestSurveyFromGitHub(sha, path);
+      
+      return res.status(200).json({data: moduleTextAndVersionResult, code: 200});
+    }
+
     else if (api === 'getSHAFromGitHubCommitData') {
       if (req.method !== 'GET') {
         return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));

--- a/utils/submission.js
+++ b/utils/submission.js
@@ -583,7 +583,7 @@ const getUserCollections = async (req, res, uid) => {
 
 /**
  * Fetch the GitHub API token from Secret Manager.
- * @returns {String} - The GitHub API token.
+ * @returns {string} - The GitHub API token.
  */
 const getGitHubToken = async () => {
     try {
@@ -638,9 +638,9 @@ const getModuleSHA = async (path) => {
  * Repair: missing SHA value in the survey data. This property should exist for all survey data in all modules.
  * Ex: Firestore -> Module3_v1 -> any document > sha: "<string value of active commit when survey was started>".
  * This function compares the survey start date with the commit history of the module.
- * @param {String} surveyStartTimestamp - The timestamp of the survey start date (ISO 8601 String).
- * @param {String} path - the file name of the module in the questionnaire repository.
- * @returns {String} - The SHA of the commit that was active when the survey was started.
+ * @param {string} surveyStartTimestamp - The timestamp of the survey start date (ISO 8601 String).
+ * @param {string} path - the file name of the module in the questionnaire repository.
+ * @returns {string} - The SHA of the commit that was active when the survey was started.
  */
 const getSHAFromGitHubCommitData = async (surveyStartTimestamp, path) => {
     try {
@@ -693,9 +693,9 @@ const getSHAFromGitHubCommitData = async (surveyStartTimestamp, path) => {
 
 /**
  * Fetch a raw file from the questionnaire repository using the GitHub API.
- * @param {String} sha - The SHA of the raw file commit to fetch.
- * @param {String} path - The path to the file in the questionnaire repository.
- * @param {String} token - The GitHub API token.} surveyStartTimestamp 
+ * @param {string} sha - The SHA of the raw file commit to fetch.
+ * @param {string} path - The path to the file in the questionnaire repository.
+ * @param {string} token - The GitHub API token.
  * @returns {Object} - The survey's module text and version number.
  */
 const getQuestSurveyFromGitHub = async (sha, path) => {
@@ -712,10 +712,10 @@ const getQuestSurveyFromGitHub = async (sha, path) => {
 /**
  * Search the GitHub API (Raw file) by commit SHA for the version number of a module at a specific commit.
  * Early versions didn't have a versioning convention. Return '1.0' for this case.
- * @param {String} sha - The SHA of the raw file commit to fetch.
- * @param {String} path - The path to the file in the questionnaire repository.
- * @param {String} token - The GitHub API token.
- * @returns {String} - The version number of the module or '1.0' if not versioned.
+ * @param {string} sha - The SHA of the raw file commit to fetch.
+ * @param {string} path - The path to the file in the questionnaire repository.
+ * @param {string} token - The GitHub API token.
+ * @returns {string} - The version number of the module or '1.0' if not versioned.
  */
 const getTextAndVersionNumberFromGitHubCommit = async (sha, path, token) => {
     try {


### PR DESCRIPTION
Related: Quest 2.0 improvements
https://github.com/episphere/connect/issues/1066

• Fetch survey data (questionnaire repo) from GitHub API with an authenticated request.
This should be more robust than using the raw file fetch and should eliminate response code 0 errors.

Note: Merge with ConnectApp PR: https://github.com/episphere/connectApp/pull/811