### PR TITLE
Update Functions Framework Call

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions');
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const { Transaction } = require('firebase-admin/firestore');
 admin.initializeApp(functions.config().firebase);


### PR DESCRIPTION
This PR addresses the following Issue:
* 
-----
## Background Details
* GCP alerted us that defaulting that would take place with Cloud Functions going to V2 instead of V1. Because of this, we need to update our import statement of `functions-framework` in order to reference the correct SDK.
-----
## Technical Changes
* Updated `require` statement in `firestore.js`