### PR TITLE
Issue#1063 - home mouthwash collection query and 5 day lag

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3,10 +3,9 @@ const admin = require('firebase-admin');
 const { Transaction } = require('firebase-admin/firestore');
 admin.initializeApp(functions.config().firebase);
 const db = admin.firestore();
-const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit, listOfCollectionsRelatedToDataDestruction, createChunkArray, twilioErrorMessages, cidToLangMapper, printDocsCount } = require('./shared');
+const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit, listOfCollectionsRelatedToDataDestruction, createChunkArray, twilioErrorMessages, cidToLangMapper, printDocsCount, getFiveDaysAgoDateISO } = require('./shared');
 const fieldMapping = require('./fieldToConceptIdMapping');
 const { isIsoDate } = require('./validation');
-const { getFiveDaysAgoDateISO } = require('./shared');
 
 const nciCode = 13;
 const nciConceptId = `517700004`;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2189,7 +2189,7 @@ const queryHomeCollectionAddressesToPrint = async () => {
         const { withdrawConsent, participantDeceasedNORC, activityParticipantRefusal, baselineMouthwashSample, 
             collectionDetails, baseline, bloodOrUrineCollected, bloodOrUrineCollectedTimestamp, yes, no } = fieldMapping;
 
-        const fiveDaysAgoISO = getFiveDaysAgoDateISO();
+        const fiveDaysAgoDateISO = getFiveDaysAgoDateISO();
         
         const snapshot = await db.collection('participants')
             .where(withdrawConsent.toString(), '==', no)
@@ -2197,7 +2197,7 @@ const queryHomeCollectionAddressesToPrint = async () => {
             .where(`${activityParticipantRefusal}.${baselineMouthwashSample}`, '==', no)
             .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollected}`, '==', yes)
             .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '>=', '2024-04-01T00:00:00.000Z')
-            .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '<=', fiveDaysAgoISO)
+            .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '<=', fiveDaysAgoDateISO)
             .select(...participantHomeCollectionKitFields)
             .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc')
             .get();
@@ -2281,13 +2281,9 @@ const processParticipantHomeMouthwashKitData = (record, printLabel) => {
     const { collectionDetails, baseline, bioKitMouthwash, firstName, lastName, address1, address2, city, state, zip } = fieldMapping;
 
     const addressLineOne = record?.[address1];
-    console.log("🚀 ~ processParticipantHomeMouthwashKitData ~ addressLineOne:", addressLineOne)
     const poBoxRegex = /\b(?:P\.?O\.?(?:\s*Box|\s+Office\s+Box)|Post\s+Office\s+Box)\b/i;
-    // If the address line one does contain a PO Box, return an empty array
     const isPOBoxMatch = poBoxRegex.test(addressLineOne);
-    // console.log("---")
-    // console.log("🚀 ~ processParticipantHomeMouthwashKitData ~ isPOBoxMatch:", isPOBoxMatch)
-    // console.log("---")
+    
     if (isPOBoxMatch) return null;
 
     const hasMouthwash = record[collectionDetails][baseline][bioKitMouthwash] !== undefined;    
@@ -2302,17 +2298,6 @@ const processParticipantHomeMouthwashKitData = (record, printLabel) => {
     connect_id: record['Connect_ID'],
     };
      
-    // console.log("Condition evaluation:", {
-    //     hasMouthwash,
-    //     printLabel,
-    //     isPOBoxMatch,
-    //     condition: (!hasMouthwash && printLabel && !isPOBoxMatch) || (hasMouthwash && !printLabel && !isPOBoxMatch),
-    //     addressLineOne,
-    //     processedRecord
-    // });
-    // console.log("---")
-
-    
     return (!hasMouthwash && printLabel) || (hasMouthwash && !printLabel)
         ? processedRecord
         : [];

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2297,7 +2297,7 @@ const processParticipantHomeMouthwashKitData = (record, printLabel) => {
     zip_code: record[zip], 
     connect_id: record['Connect_ID'],
     };
-     
+
     return (!hasMouthwash && printLabel) || (hasMouthwash && !printLabel)
         ? processedRecord
         : [];

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2180,8 +2180,6 @@ const participantHomeCollectionKitFields = [
  * Ex. [{first_name: 'John', last_name: 'Doe', address_1: '123 Main St', address_2: '', city: 'Anytown', state: 'NY', zip_code: '12345', connect_id: 123457890}, ...]
  */
 
-// logic: current date is 5 days in difference more than actual date
-
 // TODO: Suboptimal process. Would benefit from direct query on a {kitStatus: initialized} or {completed: no} variable, which could be assigned on kit creation in Biospecimen.
 // This will get progressively slower and more expensive as participants are added.
 // TODO: A sliding time window would be more efficient in the .where(<timestamp>) query.
@@ -2190,9 +2188,9 @@ const queryHomeCollectionAddressesToPrint = async () => {
     try {
         const { withdrawConsent, participantDeceasedNORC, activityParticipantRefusal, baselineMouthwashSample, 
             collectionDetails, baseline, bloodOrUrineCollected, bloodOrUrineCollectedTimestamp, yes, no } = fieldMapping;
-        
-        const fiveDaysAgoISO = getFiveDaysAgoDateISO()
 
+        const fiveDaysAgoISO = getFiveDaysAgoDateISO();
+        
         const snapshot = await db.collection('participants')
             .where(withdrawConsent.toString(), '==', no)
             .where(participantDeceasedNORC.toString(), '==', no)

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1596,6 +1596,16 @@ const unsubscribeTextObj = {
         "<p><i>Para cancelar la suscripción a los correos electrónicos sobre Connect del Instituto Nacional del Cáncer (NCI), <% haga clic aquí %>.</i></p>",
 };
 
+/**
+ * Returns a date string five days ago in ISO format
+ * @returns {string} - ISO string of the date five days ago
+ * @example "2024-08-05T00:00:00.000Z"
+*/
+const getFiveDaysAgoDateISO = () => { 
+    const currentDate = new Date();
+    return new Date(currentDate.setDate(currentDate.getDate() - 5)).toISOString();
+}
+
 module.exports = {
     getResponseJSON,
     setHeaders,
@@ -1660,5 +1670,6 @@ module.exports = {
     getSecret,
     cidToLangMapper,
     printDocsCount,
-    unsubscribeTextObj
+    unsubscribeTextObj,
+    getFiveDaysAgoDateISO
 };


### PR DESCRIPTION
This pull request addresses the following links:
- https://github.com/episphere/connect/issues/1063

Requests from issue:
- change query to get eligible home mouthwash kit participants using `desc` order (newest first)
- create 5 day lag for eligible home mouthwash kit participants to appear in query (Exclude eligible participants with `bloodOrUrineCollectedTimestamp` (740582332) within range from today's current date to 5 days before today's current date )
- Filter out P.O. Box in Address Line 1 (521824358)

Code Changes: 
- added a 'desc' argument to change OrderBy clause
- created `getFiveDaysAgoDateISO ` function and added another `where` clause to remove eligible participants with a bloodOrUrineCollectedTimestamp of five days or less than the current date.
- added [regex](https://github.com/episphere/connectFaas/compare/dev...issue%231063-sort-eligiblePt-desc-and-five-day-lag?expand=1#diff-be91e66430aa4dd2f61668d1bd17d3cb449f57947e13bfa2f6bc087919967282R2285) to test for a "p.o. box match" in Address Line 1 (521824358). While snapshot is iterated and mapped, any regex of true will be returned as `null` and filtered out of array.


Note to self:  Request new composite index for the different environment (stage & prod) 