### PR TITLE
Block MC reminder after 45 days

### DIFF
--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -33,6 +33,7 @@ async function getParticipantsForNotificationsBQ({
   notificationSpecId = "",
   conditions = {},
   cutoffTimeStr = "",
+  stopTimeStr = "",
   timeField = "",
   fieldsToFetch = [],
   limit = 100,
@@ -54,9 +55,10 @@ async function getParticipantsForNotificationsBQ({
     bqConditionArray.push(`${bqKey} ${operator} ${typeof value === "number" ? value : `"${value}"`}`);
   }
 
-  if (cutoffTimeStr && timeField) {
+  if (timeField) {
     const bqTimeField = convertToBigqueryKey(timeField);
-    bqConditionArray.push(`${bqTimeField} <= "${cutoffTimeStr}"`);
+    if (cutoffTimeStr) bqConditionArray.push(`${bqTimeField} <= "${cutoffTimeStr}"`);
+    if (stopTimeStr) bqConditionArray.push(`${bqTimeField} >= "${stopTimeStr}"`);
   }
 
   const queryStr = `SELECT ${bqFieldArray.length === 0 ? "token" : bqFieldArray.join(", ")}

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -349,6 +349,13 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
   let previousConnectId = 0;
   let hasNext = true;
   let fetchedDataArray = [];
+  let stopTimeStr = "";
+  // Temporarily block MC survey reminders after 45 days
+  if (["Baseline Clinical Menstrual Cycle Survey Reminders", "Baseline Research Menstrual Cycle Survey Reminders"].includes(notificationSpec.category)) {
+    let stopTime = new Date();
+    stopTime.setDate(stopTime.getDate() - 45);
+    stopTimeStr = stopTime.toISOString();
+  }
 
   while (hasNext) {
     try {
@@ -356,6 +363,7 @@ async function getParticipantsAndSendNotifications({ notificationSpec, cutoffTim
         notificationSpecId: notificationSpec.id,
         conditions,
         cutoffTimeStr,
+        stopTimeStr,
         timeField,
         fieldsToFetch,
         limit,


### PR DESCRIPTION
Temporarily add hard-coded 45-day restriction on MC survey reminders, to fix prod issue.
A long-term solution will be implemented shortly in September release.