### PR TITLE
Error handling prod

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -972,11 +972,9 @@ const biospecimenAPIs = async (req, res) => {
         try {
           await sendInstantNotification(requestData);
           return res.status(200).json(getResponseJSON("Success!", 200));
-        } catch (error) {
-          console.error(
-            `Error sending instant notification (${requestData.category}, ${requestData.attempt}). ${error.message}`
-          );
-          return res.status(500).json({ message: error.message, code: 500 });
+        } catch (err) {
+          console.error(err);
+          return res.status(500).json({ message: err.message, code: 500 });
         }
     }
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3616,6 +3616,7 @@ const updateSmsPermission = async (phoneNumber, isSmsPermitted) => {
 };
 
 module.exports = {
+    db,
     updateResponse,
     retrieveParticipants,
     verifyIdentity,

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -989,9 +989,9 @@ const handleIncomingSms = async (req, res) => {
     } catch (error) {
       console.error("Error updating sms permission to 'participants' collection.", error);
     }
-
-    return res.sendStatus(204);
   }
+  
+  return res.sendStatus(204);
 };
 
 module.exports = {

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -901,13 +901,15 @@ async function handleDryRun(spec) {
 
 const sendInstantNotification = async (requestData) => {
   const notificationSpec = await getNotificationSpecByCategoryAndAttempt(requestData.category, requestData.attempt);
+  const errMsg = `Error sending instant notification (${requestData.category}, ${requestData.attempt}) to participant with ID ${requestData.connectId}`;
+
   if (!notificationSpec) {
-    throw new Error(`Notification spec not found for category: "${requestData.category}", attempt: "${requestData.attempt}".`);
+    throw new Error(`${errMsg}. Notification spec not found.`);
   }
 
   const isNotificationSent = await checkIsNotificationSent(requestData.token, notificationSpec.id);
   if (isNotificationSent) {
-    throw new Error(`Notification already sent for participant with ID ${requestData.connectId}.`);
+    throw new Error(`${errMsg}. Notification already sent.`);
   }
 
   const uuidStr = uuid();
@@ -942,7 +944,6 @@ const sendInstantNotification = async (requestData) => {
       },
     },
   };
-  await sgMail.send(emailDataToSg);
 
   const currEmailRecord = {
     id: uuidStr,
@@ -961,7 +962,14 @@ const sendInstantNotification = async (requestData) => {
     uid: requestData.uid,
     read: false,
   };
-  await storeNotification(currEmailRecord);
+
+  try {
+    await sgMail.send(emailDataToSg);
+    await storeNotification(currEmailRecord);
+  } catch (err) {
+    console.error(`Error with data emailDataToSg: ${emailDataToSg}`); // Can be Removed after troubleshooting
+    throw new Error(errMsg, { cause: err });
+  }
 };
 
 const handleIncomingSms = async (req, res) => {

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -977,12 +977,12 @@ const handleIncomingSms = async (req, res) => {
   if (["START", "STOP"].includes(optinOptoutType)) {
     const isSmsPermitted = optinOptoutType === "START";
     try {
-      const docCount = await updateSmsPermission(req.body.From, isSmsPermitted);
-      return res.status(200).json({ message: `Updated ${docCount} docs`, code: 200 });
+      await updateSmsPermission(req.body.From, isSmsPermitted);
     } catch (error) {
       console.error("Error updating sms permission to 'participants' collection.", error);
-      return res.status(500).json({ message: error.message, code: 500 });
     }
+
+    return res.sendStatus(204);
   }
 };
 

--- a/utils/webhook.js
+++ b/utils/webhook.js
@@ -81,7 +81,7 @@ const webhook = async (req, res) => {
       console.log(
         `Tried to update Twilio Notify message statuses to Firestore. Total: ${req.body.DeliveryState.length}; Success: ${successCount}; Failure: ${failureCount}`
       );
-      return res.status(200).json(getResponseJSON("OK", 200));
+      return res.sendStatus(204);
     } else if (query.api === "twilio-incoming-sms") {
       return await handleIncomingSms(req, res);
     } else if (query.api === "twilio-message-status") {


### PR DESCRIPTION
Details of this PR:

-Print more detailed info when an error occurs when sending instant notifications, for easier troubleshooting
-Send status code 204 to Twilio after handling incoming messages, so that it doesn't complain with errors  12300 or 11200