### PR TITLE
1109 Fix

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -696,7 +696,7 @@ const biospecimenAPIs = async (req, res) => {
         try {
             const { assignKitToParticipant } = require('./firestore');
             const response = await assignKitToParticipant(requestData);
-            return res.status(200).json({ response, code:200 });
+            return res.status(200).json({ ...response, code:200 });
         }
         catch (error) {
             console.error(error);


### PR DESCRIPTION
assignKitToParticipant has more informative error messages, runs in a transaction, and prevents multiple baseline kits from being assigned to a participant ([1109](https://github.com/episphere/connect/issues/1109)).