### PR TITLE
await response from 'submit' endpoint

### DIFF
--- a/utils/connectApp.js
+++ b/utils/connectApp.js
@@ -1,5 +1,5 @@
 const { getResponseJSON, setHeadersDomainRestricted, getUserProfile } = require('./shared');
-const { recruitSubmit, submitSocial, getUserSurveys, getUserCollections } = require('./submission');
+const { submit, submitSocial, getUserSurveys, getUserCollections } = require('./submission');
 const { retrieveNotifications, sendEmailLink } = require('./notifications');
 const { validateToken, generateToken, updateParticipantFirebaseAuthentication, validateUsersEmailPhone } = require('./validation');
 
@@ -37,9 +37,23 @@ const connectApp = async (req, res) => {
     console.log(`PWA API: ${api}, called from uid: ${uid}`);
 
   try {
-    if (api === 'submit') return await recruitSubmit(req, res, uid);
+    if (api === 'submit') {
 
-    if (api === 'submitSocial') return submitSocial(req, res, uid);
+      if (req.method !== 'POST') {
+        return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+      }
+
+      const body = req.body;
+
+      if (!body || Object.keys(body).length === 0) {
+        return res.status(400).json(getResponseJSON('Bad request!', 400));
+      }
+
+      // all 'submit' paths return res.status(code).json({ message, code });
+      return await submit(res, body, uid);
+    }
+
+    else if (api === 'submitSocial') return submitSocial(req, res, uid);
 
     else if (api === 'getUserProfile') return getUserProfile(req, res, uid);
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -101,16 +101,19 @@ const updateResponse = async (data, uid) => {
     try{
         const snapshot = await db.collection('participants').where('state.uid', '==', uid).get();
         printDocsCount(snapshot, "updateResponse");
-        if(snapshot.size === 1) {
-            for(let doc of snapshot.docs){
-                await db.collection('participants').doc(doc.id).update(data);
-                return true;
-            }
+
+        if (snapshot.size !== 1) {
+            throw new Error(`updateResponse expected 1 document, found ${snapshot.size}. uid: ${uid}`);
         }
+
+        const docId = snapshot.docs[0].id;
+        
+        await db.collection('participants').doc(docId).update(data);
+        return true;
     }
     catch(error){
-        console.error(error);
-        return new Error(error)
+        console.error(`Error in updateResponse: ${error}`);
+        return new Error(`Error in updateResponse: ${error}`);
     }
 }
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -106,9 +106,7 @@ const updateResponse = async (data, uid) => {
             throw new Error(`updateResponse expected 1 document, found ${snapshot.size}. uid: ${uid}`);
         }
 
-        const docId = snapshot.docs[0].id;
-        
-        await db.collection('participants').doc(docId).update(data);
+        await snapshot.docs[0].ref.update(data);
         return true;
     }
     catch(error){

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -784,7 +784,7 @@ const cleanSurveyData = (data) => {
     const admin = require('firebase-admin');
     
     Object.keys(data).forEach(key => {
-        if(data[key] === null) {
+        if(data[key] == null) {
             data[key] = admin.firestore.FieldValue.delete();
         }
     });

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -784,7 +784,7 @@ const cleanSurveyData = (data) => {
     const admin = require('firebase-admin');
     
     Object.keys(data).forEach(key => {
-        if(data[key] == null) {
+        if (data[key] === null || data[key] === undefined) {
             data[key] = admin.firestore.FieldValue.delete();
         }
     });

--- a/utils/submission.js
+++ b/utils/submission.js
@@ -1,9 +1,9 @@
-const { getResponseJSON, setHeaders, logIPAddress } = require('./shared');
+const { cleanSurveyData, getResponseJSON, lockedAttributes, setHeaders, logIPAddress, moduleConceptsToCollections, moduleStatusConcepts } = require('./shared');
+const { updateResponse } = require('./firestore');
 const fieldMapping = require('./fieldToConceptIdMapping');
 
 const submit = async (res, data, uid) => {
     // Remove locked attributes.
-    const { lockedAttributes } = require('./shared');
     lockedAttributes.forEach(atr => delete data[atr]);
 
     try {
@@ -28,9 +28,6 @@ const submit = async (res, data, uid) => {
 
         // check if submitting survey
         if (keys.length === 1) {
-
-            const { moduleConceptsToCollections } = require('./shared');
-
             let key = keys[0];
             let collection = moduleConceptsToCollections[key];
 
@@ -40,21 +37,15 @@ const submit = async (res, data, uid) => {
             }
         }
 
-        const { cleanSurveyData } = require('./shared');
         data = cleanSurveyData(data);
-
-        const { updateResponse } = require('./firestore');
 
         // response is either true or an Error object
         const response = await updateResponse(data, uid);
-
         if (response) {
             let moduleComplete = false;
             let calculateScores = false;
 
             keys.forEach(key => {
-                const { moduleStatusConcepts } = require('./shared');
-
                 if (moduleStatusConcepts[key] && data[key] === 231311385) {
                     moduleComplete = true;
 
@@ -65,7 +56,6 @@ const submit = async (res, data, uid) => {
             })
 
             if (moduleComplete) {
-
                 const { checkDerivedVariables } = require('./validation');
                 const { getTokenForParticipant, retrieveUserProfile } = require('./firestore');
 


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/1168 

Update the submit endpoint to await the response and return a response for all cases.

Implementation: This is used for response confirmation, in-app handling & communication, and question reversion when a response to a question fails to update server-side in Quest 2.
