### PR TITLE
Issue#1098 additional kit reports home mouthwash

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -923,19 +923,23 @@ const biospecimenAPIs = async (req, res) => {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
         }
         try {
-            const statusType = req.query.type;
-            
-            const collectionId = req.query.collectionId;
-            const connectId = req.query.connectId;
-            const returnKitTrackingNumber = req.query.returnKitTrackingNum;
-            const dateReceived = req.query.dateReceived;
+            const { 
+                type: statusType,
+                collectionId, 
+                connectId, 
+                returnKitTrackingNum: returnKitTrackingNumber, 
+                dateReceived
+            } = req.query;
 
-            const filters = {
-                collectionId: collectionId,
-                connectId: connectId,
-                returnKitTrackingNumber: returnKitTrackingNumber,
-                receivedDateTime: dateReceived
-            };
+
+            const filters = {};
+
+            // add filters to filters object if they exist
+            if (collectionId) filters["collectionId"] = collectionId;
+            if (connectId) filters["connectId"] = connectId;
+            if (returnKitTrackingNumber) filters["returnKitTrackingNumber"] = returnKitTrackingNumber;
+            if (dateReceived) filters["receivedDateTime"] = dateReceived;
+            
 
             const kitStatusOptions = [
                 fieldMapping.pending.toString(),


### PR DESCRIPTION
This PR is related to:
- https://github.com/episphere/connect/issues/1098
- https://github.com/NCI-C4CP/biospecimen/pull/837
---
Requirements:

- Create additional Kit Status Reports (pending, assigned, received) for FNL team in BPTL Home Collection Reports section page
- Include a filter for Kit Status Reports received. Have the filters Collection ID, Connect ID, Return Kit Tracking Number, and Date Received added.

Code changes overview:
- Updated endpoint for getParticipantsByKitStatus. 
- Added logic for pending, assigned and received reports
- Added endpoint Filter search for received Kit Status Reports

