### PR TITLE
Prevents requesting home kits for non-verified participants

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2864,6 +2864,8 @@ const requestHomeKit = async(connectId) => {
                 throw new Error('Participant has withdrawn consent.');
             } else if (data[fieldMapping.participantDeceasedNORC] == fieldMapping.yes) {
                 throw new Error('Participant is deceased.');
+            } else if (data[fieldMapping.verificationStatus] !== fieldMapping.verified) {
+                throw new Error('Participant is not verified.');
             }
             const updatedParticipantObject = getHomeMWKitData(data);
             transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);


### PR DESCRIPTION
Updated requestHomeKit in firestore.js to reject requests for any participants whose verification status is not verified. Follow-up to testing on [1020](https://github.com/episphere/connect/issues/1020).