### PR TITLE
Per feedback, R2 home MW kits can now have addressUndeliverable updated

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1468,7 +1468,7 @@ describe('biospecimen', async () => {
                 });
     
             });
-            it('Should prevent a participant whose replacement kitStatus is address undeliverable from obtaining a replacement', () => {
+            it('Should update a participant whose R1 kitStatus is address undeliverable to initialized', () => {
                 const data = {
                     [fieldToConceptIdMapping.firstName]: 'First',
                     [fieldToConceptIdMapping.lastName]: 'Last',
@@ -1528,6 +1528,45 @@ describe('biospecimen', async () => {
                 expect(shared.getHomeMWKitData.bind(null, data)).to.throw(/Unrecognized kit status fake/);
             });
 
+        });
+        it('Should update a participant whose R2 kitStatus is address undeliverable to initialized', () => {
+            const data = {
+                [fieldToConceptIdMapping.firstName]: 'First',
+                [fieldToConceptIdMapping.lastName]: 'Last',
+                [fieldToConceptIdMapping.address1]: '123 Fake Street',
+                [fieldToConceptIdMapping.city]: 'City',
+                [fieldToConceptIdMapping.state]: 'PA',
+                [fieldToConceptIdMapping.zip]: '19104',
+                'Connect_ID': 123456789,
+                [fieldToConceptIdMapping.collectionDetails]: {
+                    [fieldToConceptIdMapping.baseline]: {
+                        [fieldToConceptIdMapping.bioKitMouthwash]: {
+                            [fieldToConceptIdMapping.kitStatus]: fieldToConceptIdMapping.addressPrinted
+                        },
+                        [fieldToConceptIdMapping.bioKitMouthwashBL1]: {
+                            [fieldToConceptIdMapping.kitStatus]: fieldToConceptIdMapping.received
+                        },
+                        [fieldToConceptIdMapping.bioKitMouthwashBL2]: {
+                            [fieldToConceptIdMapping.kitStatus]: fieldToConceptIdMapping.addressUndeliverable
+                        }
+                    }
+                }
+            };
+            const updates = shared.getHomeMWKitData(data);
+            const clonedUpdates = Object.assign({}, updates);
+            delete clonedUpdates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.dateKitRequested}`];
+            assert.closeTo
+                (+new Date(updates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.dateKitRequested}`]),
+                +new Date(), 
+                60000, 
+                'Date kit requested is within a minute of test completion'
+            );
+
+            assert.deepEqual(clonedUpdates, {
+                [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized
+                },
+                `Kit status address undeliverable eligible for second replacement kit`);
         });
         it('Should prevent a participant who already has a second replacement kit from obtaining another', () => {
             const data = {

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1054,20 +1054,20 @@ const getHomeMWKitData = (data) => {
     } = fieldMapping;
     let fieldPath = `${collectionDetails}.${baseline}.${bioKitMouthwash}`;
     let updatedParticipantObject = {};
-    
-    if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]) {
-        // If two replacements, they are out of replacement kits; error out.
-        throw new Error('Participant has exceeded supported number of replacement kits.');
+
+    const participantIsEligible = !!processParticipantHomeMouthwashKitData(data, true);
+
+    if(!participantIsEligible) {
+        throw new Error('Participant address information is invalid.');
     }
-
-   const participantIsEligible = !!processParticipantHomeMouthwashKitData(data, true);
-
-   if(!participantIsEligible) {
-    throw new Error('Participant address information is invalid.');
-   }
-
-   
-    if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1]) {
+    
+    if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]?.[kitStatus] === addressUndeliverable) {
+        // If their R2 address is marked as undeliverable, change it to initialized.
+        fieldPath = `${collectionDetails}.${baseline}.${bioKitMouthwashBL2}`;
+    } else if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]) {
+        // If two replacements otherwise, they are out of replacement kits; error out.
+        throw new Error('Participant has exceeded supported number of replacement kits.');
+    } else if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1]) {
         // If one replacement, mark as eligible for second replacement
         switch(data[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1][kitStatus]) {
             case undefined:


### PR DESCRIPTION
Changes:
test.js:
* New test case added for undeliverable R2 kit scenario
* Some test description updates for accuracy

shared.js:
* getHomeMWKitData updated so that when passed a participant whose R2 kit status is marked as address undeliverable, it will update the R2 kit to initialized.