### PR TITLE
1326 Followup

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2653,7 +2653,6 @@ const processRequestAKitConditions = async (updateDb, docId) => {
         }
         const {getParticipantsForRequestAKitBQ} = require('./bigquery');
         const {queryStr, rows} = await getParticipantsForRequestAKitBQ(conditionsArr, sortsArr, updateDb ? limit : undefined);
-        console.log('rows', JSON.stringify(rows, null, '\t'));
         const participantsToUpdate = rows.map(row => row.token);
 
         if(updateDb) {


### PR DESCRIPTION
Fixed an issue where null values were being omitted in != checks where we wanted them to be included. != checks exclude NULL values and "IS NULL" conditions must be separately included.