### PR TITLE
Update Codes -> Do Not Text

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -5006,7 +5006,7 @@ const processTwilioEvent = async (event) => {
 
         await doc.ref.update(eventRecord);
 
-        if (event.ErrorCode === "21610") {
+        if (["21610", "30004", "30006"].includes(event.ErrorCode)) {
             await updateSmsPermission(docData.phone, false);
         }
 


### PR DESCRIPTION
Issue Addressed: https://github.com/episphere/connect/issues/1545

This pull request updates the logic for handling Twilio event error codes in the `processTwilioEvent` function. Now, the system will revoke SMS permissions for additional error codes, not just one.

**Twilio event error handling:**

* Expanded the check in `processTwilioEvent` in `utils/firestore.js` to revoke SMS permissions when `event.ErrorCode` is `"21610"`, `"30004"`, or `"30006"`, instead of only `"21610"`.