### PR TITLE
diff - version override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1529,11 +1529,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4154,16 +4153,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/sinon/node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,11 @@
     "qs": "6.14.1 for CVE-2025-15284",
     "jws": "4.0.1 for GHSA-869p-cjfg-cm3x",
     "js-yaml": "4.1.1 for GHSA-mh29-5h37-fv8m",
-    "node-forge": "1.3.2 for GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, GHSA-65ch-62r8-g69g"
+    "node-forge": "1.3.2 for GHSA-554w-wpv2-vw27, GHSA-5gfm-wpxj-wjgq, GHSA-65ch-62r8-g69g",
+    "diff": "8.0.3 for GHSA-73rr-hh4g-fpgx"
   },
   "overrides": {
+    "diff": "8.0.3",
     "qs": "6.14.1",
     "jws": "4.0.1",
     "js-yaml": "4.1.1",


### PR DESCRIPTION
Alerts Addressed: 
https://github.com/NCI-C4CP/connectFaas/security/dependabot/88
https://github.com/NCI-C4CP/connectFaas/security/dependabot/87

This pull request adds a security-related dependency override to address a known vulnerability. Specifically, it locks the `diff` package to version `8.0.3` to remediate the `GHSA-73rr-hh4g-fpgx` advisory.

Dependency security updates:

* Added `diff` version `8.0.3` to both the `resolutions` and `overrides` sections in `package.json` to address security advisory GHSA-73rr-hh4g-fpgx.