### PR TITLE
1596 and 1608 support

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -796,6 +796,21 @@ const biospecimenAPIs = async (req, res) => {
         }
     }
 
+    else if(api === 'getKitsShippedNotReceived') {
+        if(req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+        try {
+            const { queryKitsByShippedAndAssignedStatus } = require('./firestore');
+            const response = await queryKitsByShippedAndAssignedStatus();
+            return res.status(200).json({data: response, code:200});
+        }
+        catch(error) {
+            console.error('Error querying kits', error);
+            return res.status(500).json(getResponseJSON(error.message, 500));
+        }
+    }
+
     else if(api === 'kitStatusToParticipant') {
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2661,6 +2661,7 @@ const processRequestAKitConditions = async (updateDb, docId) => {
             // Participant initial kit status is pending or blank
             `d_${collectionDetails}.d_${baseline}.d_${bioKitMouthwash}.d_${kitStatus} = ${pending} OR d_${collectionDetails}.d_${baseline}.d_${bioKitMouthwash}.d_${kitStatus} IS NULL`,
             `d_${baselineMouthwashCollected} != ${yes} OR d_${baselineMouthwashCollected} IS NULL`, // Participant does not already have a mouthwash sample collected
+            `d_${collectionDetails}.d_${baseline}.d_${bioKitMouthwash}.d_${kitRequestEligible} IS NULL` // Participant is not already eligible to request a kit
 
         ];
         let sortsArr = [];
@@ -3164,6 +3165,25 @@ const queryKitsByReceivedDate = async (receivedDateTimestamp) => {
     // Because there are no sorts on biospecSnapshot, we don't need to care about order,
     // so just whatever order is returned here is fine
     return Object.keys(kitDict).map(key => kitDict[key]);
+}
+
+const queryKitsByShippedAndAssignedStatus = async () => {
+    // Find all kitAssemblies in shipped or assigned status,
+
+    const kitSnapshot = await db
+        .collection('kitAssembly')
+        .where(Filter.or(
+            Filter.where(`${fieldMapping.kitStatus}`, '==', fieldMapping.assigned),
+            Filter.where(`${fieldMapping.kitStatus}`, '==', fieldMapping.shipped)
+        ))
+        .get();
+    if (kitSnapshot.size === 0) {
+        return false;
+    }
+
+    const kitDocs = kitSnapshot.docs.map(doc => doc.data());
+
+    return kitDocs;
 }
 
 const eligibleParticipantsForKitAssignment = async () => {
@@ -5868,6 +5888,7 @@ module.exports = {
     processTwilioEvent,
     getSpecimenAndParticipant,
     queryKitsByReceivedDate,
+    queryKitsByShippedAndAssignedStatus,
     getParticipantCancerOccurrences,
     writeCancerOccurrences,
     writeBirthdayCard,


### PR DESCRIPTION
Implements new backend endpoint for [1596](https://github.com/episphere/connect/issues/1596) and adds new default condition for processing request a kit conditions requested in [1608](https://github.com/episphere/connect/issues/1608).

Changes:

biospecimen.js:
* Adds new API endpoint getKitsShippedNotReceived

firestore.js:
* Adds new condition for "Participant is not already eligible to request a kit" to processRequestAKitConditions
* queryKitsByShippedAndAssignedStatus method added and exported to query for all kits in shipped or assigned status