### PR TITLE
GCP CF Clean-Up

### DIFF
--- a/config/dev/physicalActivityROI.yaml
+++ b/config/dev/physicalActivityROI.yaml
@@ -4,7 +4,7 @@ steps:
   args: [
     'functions', 
     'deploy', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--trigger-http', 
     '--runtime=${_RUNTIME}', 
     '--timeout=${_TIMEOUT}', 
@@ -16,7 +16,7 @@ steps:
   args: [
     'functions', 
     'add-iam-policy-binding', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--member=${_MEMBER}', 
     '--role=${_ROLE}'
   ]

--- a/config/prod/physicalActivityROI.yaml
+++ b/config/prod/physicalActivityROI.yaml
@@ -4,7 +4,7 @@ steps:
   args: [
     'functions', 
     'deploy', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--trigger-http', 
     '--runtime=${_RUNTIME}', 
     '--timeout=${_TIMEOUT}', 
@@ -16,7 +16,7 @@ steps:
   args: [
     'functions', 
     'add-iam-policy-binding', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--member=${_MEMBER}', 
     '--role=${_ROLE}'
   ]

--- a/config/stage/physicalActivityROI.yaml
+++ b/config/stage/physicalActivityROI.yaml
@@ -4,7 +4,7 @@ steps:
   args: [
     'functions', 
     'deploy', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--trigger-http', 
     '--runtime=${_RUNTIME}', 
     '--timeout=${_TIMEOUT}', 
@@ -16,7 +16,7 @@ steps:
   args: [
     'functions', 
     'add-iam-policy-binding', 
-    'physicalActivityROI', 
+    'physicalActivity', 
     '--member=${_MEMBER}', 
     '--role=${_ROLE}'
   ]

--- a/test/unit/apiEndpoints.test.js
+++ b/test/unit/apiEndpoints.test.js
@@ -11,10 +11,9 @@ beforeAll(() => {
     });
 
     const { incentiveCompleted, eligibleForIncentive } = require('../../utils/incentive');
-    const { getToken, validateUsersEmailPhone } = require('../../utils/validation');
+    const { getToken } = require('../../utils/validation');
     const { getFilteredParticipants, getParticipants, identifyParticipant } = require('../../utils/submission');
     const { submitParticipantsData, updateParticipantData, getBigQueryData } = require('../../utils/sites');
-    const { getParticipantNotification } = require('../../utils/notifications');
     const { dashboard } = require('../../utils/dashboard');
     const { connectApp } = require('../../utils/connectApp');
     const { biospecimenAPIs } = require('../../utils/biospecimen');
@@ -26,14 +25,12 @@ beforeAll(() => {
         incentiveCompleted,
         participantsEligibleForIncentive: eligibleForIncentive,
         getParticipantToken: getToken,
-        validateUsersEmailPhone,
         getFilteredParticipants,
         getParticipants,
         identifyParticipant,
         submitParticipantsData,
         updateParticipantData,
         getBigQueryData,
-        getParticipantNotification,
         dashboard,
         app: connectApp,
         biospecimen: biospecimenAPIs,
@@ -77,7 +74,6 @@ describe('API Endpoint Method Guards', () => {
             ['submitParticipantsData', () => api.submitParticipantsData],
             ['updateParticipantData', () => api.updateParticipantData],
             ['getBigQueryData', () => api.getBigQueryData],
-            ['getParticipantNotification', () => api.getParticipantNotification],
             ['dashboard', () => api.dashboard],
             ['app', () => api.app],
             ['biospecimen', () => api.biospecimen],
@@ -106,7 +102,6 @@ describe('API Endpoint Method Guards', () => {
             ['submitParticipantsData', () => api.submitParticipantsData, 'GET', 'Only POST requests are accepted!'],
             ['updateParticipantData', () => api.updateParticipantData, 'GET', 'Only POST requests are accepted!'],
             ['getBigQueryData', () => api.getBigQueryData, 'POST', 'Only GET requests are accepted!'],
-            ['getParticipantNotification', () => api.getParticipantNotification, 'POST', 'Only GET requests are accepted!'],
             ['webhook', () => api.webhook, 'GET', 'Only POST requests are accepted!'],
         ];
 

--- a/test/unit/apiEndpoints.test.js
+++ b/test/unit/apiEndpoints.test.js
@@ -95,7 +95,6 @@ describe('API Endpoint Method Guards', () => {
             ['incentiveCompleted', () => api.incentiveCompleted, 'GET', 'Only POST requests are accepted!'],
             ['participantsEligibleForIncentive', () => api.participantsEligibleForIncentive, 'POST', 'Only GET requests are accepted!'],
             ['getParticipantToken', () => api.getParticipantToken, 'GET', 'Only POST requests are accepted!'],
-            ['validateUsersEmailPhone', () => api.validateUsersEmailPhone, 'POST', 'Only GET requests are accepted!'],
             ['getFilteredParticipants', () => api.getFilteredParticipants, 'POST', 'Only GET requests are accepted!'],
             ['getParticipants', () => api.getParticipants, 'POST', 'Only GET requests are accepted!'],
             ['identifyParticipant', () => api.identifyParticipant, 'PUT', 'Only GET or POST requests are accepted!'],
@@ -146,32 +145,6 @@ describe('API Endpoint Method Guards', () => {
                 expect(res.statusCode).toBe(401);
             });
         }
-    });
-
-    describe('validateUsersEmailPhone account lookup', () => {
-        it('should return accountExists true/false based on lookup result', async () => {
-            const verifyStub = vi.spyOn(firestore, 'verifyUsersEmailOrPhone');
-            verifyStub.mockResolvedValueOnce(false);
-            verifyStub.mockResolvedValueOnce(true);
-
-            const missingUserRes = await invoke(api.validateUsersEmailPhone, 'GET', {
-                query: {
-                    email: 'nonexistent@example.com',
-                },
-            });
-            expect(missingUserRes.statusCode).toBe(200);
-            expect(missingUserRes._getJSONData().code).toBe(200);
-            expect(missingUserRes._getJSONData().data.accountExists).toBe(false);
-
-            const existingUserRes = await invoke(api.validateUsersEmailPhone, 'GET', {
-                query: {
-                    email: 'existing@example.com',
-                },
-            });
-            expect(existingUserRes.statusCode).toBe(200);
-            expect(existingUserRes._getJSONData().code).toBe(200);
-            expect(existingUserRes._getJSONData().data.accountExists).toBe(true);
-        });
     });
 
     describe('heartbeat success path', () => {


### PR DESCRIPTION
**Deployment configuration updates:**

* Renamed the deployed Cloud Function from `physicalActivityROI` to `physicalActivity` in the deployment and IAM policy binding steps for all environments: `dev`, `stage`, and `prod` (`config/dev/physicalActivityROI.yaml`, `config/stage/physicalActivityROI.yaml`, `config/prod/physicalActivityROI.yaml`). [[1]](diffhunk://#diff-54699ad2d8a99fd29c64a6479392fa568dac71aac1198945cb7e91630c743156L7-R7) [[2]](diffhunk://#diff-54699ad2d8a99fd29c64a6479392fa568dac71aac1198945cb7e91630c743156L19-R19) [[3]](diffhunk://#diff-edd806623b8c5355fe4d8c02b3e8a681267575153188c66f860cb85144057a4dL7-R7) [[4]](diffhunk://#diff-edd806623b8c5355fe4d8c02b3e8a681267575153188c66f860cb85144057a4dL19-R19) [[5]](diffhunk://#diff-65f2a8ea17b6380866845257bfe67db79a17a2dd7a57af4751597a7128d1dbb6L7-R7) [[6]](diffhunk://#diff-65f2a8ea17b6380866845257bfe67db79a17a2dd7a57af4751597a7128d1dbb6L19-R19)

**Test code cleanup:**

* Removed unused imports of `validateUsersEmailPhone` and `getParticipantNotification` from `test/unit/apiEndpoints.test.js`.
* Removed references to `validateUsersEmailPhone` and `getParticipantNotification` from the test API object and related test cases in `test/unit/apiEndpoints.test.js`. [[1]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbL29-L36) [[2]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbL80) [[3]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbL109)