### PR TITLE
Handle matching to & cc/bcc edge case

### DIFF
--- a/test/mocks/helpers/mockHelpers.js
+++ b/test/mocks/helpers/mockHelpers.js
@@ -60,6 +60,29 @@ class MockHelpers {
                 },
                 Transaction: function Transaction() {},
                 Filter: {},
+                Timestamp: {
+                    fromMillis: vi.fn((ms) => ({
+                        _seconds: Math.floor(ms / 1000),
+                        _nanoseconds: 0,
+                        toMillis: () => ms,
+                        toDate: () => new Date(ms),
+                    })),
+                    fromDate: vi.fn((date) => ({
+                        _seconds: Math.floor(date.getTime() / 1000),
+                        _nanoseconds: 0,
+                        toMillis: () => date.getTime(),
+                        toDate: () => date,
+                    })),
+                    now: vi.fn(() => {
+                        const ms = Date.now();
+                        return {
+                            _seconds: Math.floor(ms / 1000),
+                            _nanoseconds: 0,
+                            toMillis: () => ms,
+                            toDate: () => new Date(ms),
+                        };
+                    }),
+                },
             },
         };
 

--- a/test/unit/emailSuppression.test.js
+++ b/test/unit/emailSuppression.test.js
@@ -927,6 +927,26 @@ describe("Email Suppression System", () => {
         status: "planned",
         updatedAt: "2026-04-01T12:00:00.000Z",
       }), { merge: true });
+
+      // TTL contract: the run doc and every batch doc has an `expiresAt` timestamp set 45 days from write time.
+      const expectedExpiresAtSeconds = Math.floor(
+        new Date("2026-05-16T12:00:00.000Z").getTime() / 1000,
+      );
+      expect(runSetSpies.get("run-save-plan")).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expiresAt: expect.objectContaining({ _seconds: expectedExpiresAtSeconds }),
+        }),
+        { merge: true },
+      );
+      // Spot-check that batch docs received the same expiresAt (TTL doesn't cascade).
+      expect(firstBatch.set).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          expiresAt: expect.objectContaining({ _seconds: expectedExpiresAtSeconds }),
+        }),
+        { merge: true },
+      );
       vi.useRealTimers();
     });
 

--- a/test/unit/notifications.test.js
+++ b/test/unit/notifications.test.js
@@ -270,6 +270,8 @@ describe("Notifications Unit Tests", () => {
     process.env.TWILIO_ACCOUNT_SID = "secret/twilio-account";
     process.env.TWILIO_AUTH_TOKEN = "secret/twilio-auth";
     process.env.TWILIO_MESSAGING_SERVICE_SID = "secret/twilio-service";
+    process.env.BULK_WORKER_URI_DEFAULT = "https://processnotificationbatchbulkdefault-test-uc.a.run.app";
+    process.env.BULK_WORKER_URI_MICROSOFT = "https://processnotificationbatchbulkmicrosoft-test-uc.a.run.app";
 
     // Mock global fetch
     fetchStub = vi.fn();
@@ -919,6 +921,7 @@ describe("Notifications Unit Tests", () => {
         specId: "spec-bulk-threshold",
         runSequence: 3,
       });
+      expect(opts.uri).toBe("https://processnotificationbatchbulkdefault-test-uc.a.run.app");
       expect(firestoreMock.saveBulkNotificationRunPlan).toHaveBeenCalledTimes(1);
       const [{ runDoc, batchDocs }] = firestoreMock.saveBulkNotificationRunPlan.mock.calls[0];
       expect(runDoc).toMatchObject({
@@ -3332,6 +3335,131 @@ describe("SmsBatchSender", () => {
 
       await sender.waitForSpec("spec1");
       expect(delayFn).toHaveBeenCalled();
+    });
+  });
+});
+
+// Error contract helpers.
+describe("buildBulkWorkerUri / validateBulkWorkerUri", () => {
+  const { buildBulkWorkerUri, validateBulkWorkerUri } = require("../../utils/notifications");
+
+  const DEV_DEFAULT_URI = "https://processnotificationbatchbulkdefault-cbodno4evq-uc.a.run.app";
+  const DEV_MS_URI = "https://processnotificationbatchbulkmicrosoft-cbodno4evq-uc.a.run.app";
+
+  const originalEnv = {};
+  beforeEach(() => {
+    originalEnv.default = process.env.BULK_WORKER_URI_DEFAULT;
+    originalEnv.microsoft = process.env.BULK_WORKER_URI_MICROSOFT;
+    originalEnv.project = process.env.GCLOUD_PROJECT;
+    delete process.env.BULK_WORKER_URI_DEFAULT;
+    delete process.env.BULK_WORKER_URI_MICROSOFT;
+    process.env.GCLOUD_PROJECT = "nih-nci-dceg-connect-dev";
+  });
+  afterEach(() => {
+    if (originalEnv.default === undefined) delete process.env.BULK_WORKER_URI_DEFAULT;
+    else process.env.BULK_WORKER_URI_DEFAULT = originalEnv.default;
+    if (originalEnv.microsoft === undefined) delete process.env.BULK_WORKER_URI_MICROSOFT;
+    else process.env.BULK_WORKER_URI_MICROSOFT = originalEnv.microsoft;
+    if (originalEnv.project === undefined) delete process.env.GCLOUD_PROJECT;
+    else process.env.GCLOUD_PROJECT = originalEnv.project;
+  });
+
+  describe("resolution order", () => {
+    it("reads from appSettings.notifications.bulkWorkerUriDefault when no env override", () => {
+      const settings = { bulkWorkerUriDefault: DEV_DEFAULT_URI };
+      expect(buildBulkWorkerUri("default", settings)).toBe(DEV_DEFAULT_URI);
+    });
+
+    it("reads from appSettings.notifications.bulkWorkerUriMicrosoft when no env override", () => {
+      const settings = { bulkWorkerUriMicrosoft: DEV_MS_URI };
+      expect(buildBulkWorkerUri("microsoft", settings)).toBe(DEV_MS_URI);
+    });
+
+    it("env var override wins over appSettings for default lane", () => {
+      const settings = { bulkWorkerUriDefault: DEV_DEFAULT_URI };
+      process.env.BULK_WORKER_URI_DEFAULT = "https://override-default-uc.a.run.app";
+      expect(buildBulkWorkerUri("default", settings)).toBe("https://override-default-uc.a.run.app");
+    });
+
+    it("env var override wins over appSettings for microsoft lane", () => {
+      const settings = { bulkWorkerUriMicrosoft: DEV_MS_URI };
+      process.env.BULK_WORKER_URI_MICROSOFT = "https://override-ms-uc.a.run.app";
+      expect(buildBulkWorkerUri("microsoft", settings)).toBe("https://override-ms-uc.a.run.app");
+    });
+
+    it("trims whitespace from the resolved URI", () => {
+      const settings = { bulkWorkerUriDefault: `  ${DEV_DEFAULT_URI}  ` };
+      expect(buildBulkWorkerUri("default", settings)).toBe(DEV_DEFAULT_URI);
+    });
+  });
+
+  describe("not-found diagnostics", () => {
+    it("throws naming the appSettings field, project, and gcloud lookup command when URI missing", () => {
+      // No env override, no appSettings field — the worst-case diagnostic test.
+      expect(() => buildBulkWorkerUri("default", {})).toThrow(/bulkWorkerUriDefault/);
+      expect(() => buildBulkWorkerUri("default", {})).toThrow(/nih-nci-dceg-connect-dev/);
+      expect(() => buildBulkWorkerUri("default", {})).toThrow(/gcloud run services describe processnotificationbatchbulkdefault/);
+      expect(() => buildBulkWorkerUri("default", {})).toThrow(/appName == "connectFaas"/);
+    });
+
+    it("error message names the microsoft lane and its lookup command separately", () => {
+      expect(() => buildBulkWorkerUri("microsoft", {})).toThrow(/bulkWorkerUriMicrosoft/);
+      expect(() => buildBulkWorkerUri("microsoft", {})).toThrow(/processnotificationbatchbulkmicrosoft/);
+    });
+
+    it("throws for an unknown lane with a list of accepted lanes", () => {
+      expect(() => buildBulkWorkerUri("unrecognized-lane", {})).toThrow(/Unknown bulk lane/);
+      expect(() => buildBulkWorkerUri("unrecognized-lane", {})).toThrow(/default/);
+      expect(() => buildBulkWorkerUri("unrecognized-lane", {})).toThrow(/microsoft/);
+    });
+
+    it("treats explicit null/empty string in appSettings the same as missing", () => {
+      expect(() => buildBulkWorkerUri("default", { bulkWorkerUriDefault: null })).toThrow(/bulkWorkerUriDefault/);
+      expect(() => buildBulkWorkerUri("default", { bulkWorkerUriDefault: "" })).toThrow(/bulkWorkerUriDefault/);
+    });
+  });
+
+  describe("wrong-URI diagnostics", () => {
+    it("rejects non-string URIs (e.g. accidentally storing a number in Firestore)", () => {
+      expect(() => buildBulkWorkerUri("default", { bulkWorkerUriDefault: 12345 })).toThrow(/must be a string/);
+    });
+
+    it("rejects http:// URIs and names the source", () => {
+      expect(() => validateBulkWorkerUri("http://example.run.app", "default", "test source")).toThrow(/must use https/);
+      expect(() => validateBulkWorkerUri("http://example.run.app", "default", "test source")).toThrow(/test source/);
+    });
+
+    it("rejects malformed URLs", () => {
+      expect(() => validateBulkWorkerUri("not a url at all", "default", "test source")).toThrow(/not a valid URL/);
+    });
+
+    it("rejects whitespace-only URIs", () => {
+      expect(() => validateBulkWorkerUri("   ", "default", "test source")).toThrow(/is empty/);
+    });
+
+    it("error from env-var override names the env var (not the appSettings field)", () => {
+      process.env.BULK_WORKER_URI_DEFAULT = "ftp://wrong-protocol.run.app";
+      expect(() => buildBulkWorkerUri("default", {})).toThrow(/BULK_WORKER_URI_DEFAULT env var/);
+    });
+
+    it("error from appSettings names the field (not an env var)", () => {
+      const settings = { bulkWorkerUriDefault: "ftp://wrong-protocol.run.app" };
+      expect(() => buildBulkWorkerUri("default", settings)).toThrow(/appSettings\.notifications\.bulkWorkerUriDefault/);
+    });
+
+    it("warns (does not throw) for a URI that's https but not a .run.app hostname", () => {
+      // Custom domains are technically valid; flag for operator review without blocking dispatch.
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(() =>
+          validateBulkWorkerUri("https://custom-domain.example.com", "default", "test source"),
+        ).not.toThrow();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("does not end with \".run.app\""),
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
   });
 });

--- a/test/unit/notifications.test.js
+++ b/test/unit/notifications.test.js
@@ -779,6 +779,90 @@ describe("Notifications Unit Tests", () => {
 
       expect(sgMailMock.send).toHaveBeenCalledTimes(1);
     });
+
+    describe("CC dedupe vs primary recipient", () => {
+      // SendGrid rejects a personalization with the same address in
+      // both `to` and `cc` ("Each email address ... should be unique...").
+      beforeEach(() => {
+        sgMailMock.send.mockResolvedValue([{ statusCode: 202 }]);
+        sharedMock.getSecret.mockResolvedValue("fake-api-key");
+        sharedMock.developmentTier = "PROD";
+        process.env.GCLOUD_SENDGRID_SECRET = "secret/sendgrid-key";
+      });
+
+      it("drops a single-string cc that matches to (exact)", async () => {
+        await notificationsModule.sendEmail("connectcc@nih.gov", "Subject", "<p>Body</p>", "connectcc@nih.gov");
+        const msg = sgMailMock.send.mock.calls[0][0];
+        expect(msg.cc).toBeUndefined();
+      });
+
+      it("drops a single-string cc that matches to (case-insensitive + whitespace)", async () => {
+        await notificationsModule.sendEmail("connectcc@nih.gov", "Subject", "<p>Body</p>", "  ConnectCC@NIH.gov  ");
+        const msg = sgMailMock.send.mock.calls[0][0];
+        expect(msg.cc).toBeUndefined();
+      });
+
+      it("keeps a single-string cc that differs from to", async () => {
+        await notificationsModule.sendEmail("kpsite@example.com", "Subject", "<p>Body</p>", "connectcc@nih.gov");
+        const msg = sgMailMock.send.mock.calls[0][0];
+        expect(msg.cc).toBe("connectcc@nih.gov");
+      });
+
+      it("filters an array cc to remove only the entries matching to", async () => {
+        await notificationsModule.sendEmail(
+          "kpsite@example.com",
+          "Subject",
+          "<p>Body</p>",
+          ["connectcc@nih.gov", "kpsite@example.com", "ops@nih.gov"],
+        );
+        const msg = sgMailMock.send.mock.calls[0][0];
+        expect(msg.cc).toEqual(["connectcc@nih.gov", "ops@nih.gov"]);
+      });
+
+      it("drops cc entirely when every array entry matches to", async () => {
+        await notificationsModule.sendEmail(
+          "connectcc@nih.gov",
+          "Subject",
+          "<p>Body</p>",
+          ["connectcc@nih.gov", "ConnectCC@nih.gov"],
+        );
+        const msg = sgMailMock.send.mock.calls[0][0];
+        expect(msg.cc).toBeUndefined();
+      });
+
+      it("drops cc when value is falsy or empty array", async () => {
+        await notificationsModule.sendEmail("kpsite@example.com", "Subject", "<p>Body</p>", "");
+        expect(sgMailMock.send.mock.calls[0][0].cc).toBeUndefined();
+
+        await notificationsModule.sendEmail("kpsite@example.com", "Subject", "<p>Body</p>", []);
+        expect(sgMailMock.send.mock.calls[1][0].cc).toBeUndefined();
+
+        await notificationsModule.sendEmail("kpsite@example.com", "Subject", "<p>Body</p>");
+        expect(sgMailMock.send.mock.calls[2][0].cc).toBeUndefined();
+      });
+    });
+
+    describe("dedupeCcAgainstTo helper", () => {
+      it("returns undefined for falsy cc inputs", () => {
+        const { dedupeCcAgainstTo } = notificationsModule;
+        expect(dedupeCcAgainstTo(undefined, "a@x.com")).toBeUndefined();
+        expect(dedupeCcAgainstTo(null, "a@x.com")).toBeUndefined();
+        expect(dedupeCcAgainstTo("", "a@x.com")).toBeUndefined();
+        expect(dedupeCcAgainstTo([], "a@x.com")).toBeUndefined();
+      });
+
+      it("compares emails case-insensitively and trim-tolerantly", () => {
+        const { dedupeCcAgainstTo } = notificationsModule;
+        expect(dedupeCcAgainstTo("  A@X.com ", "a@x.com")).toBeUndefined();
+        expect(dedupeCcAgainstTo(["A@X.COM", "b@x.com"], "a@x.com")).toEqual(["b@x.com"]);
+      });
+
+      it("preserves the original cc shape (string vs array) when no dedupe applies", () => {
+        const { dedupeCcAgainstTo } = notificationsModule;
+        expect(dedupeCcAgainstTo("b@x.com", "a@x.com")).toBe("b@x.com");
+        expect(dedupeCcAgainstTo(["b@x.com", "c@x.com"], "a@x.com")).toEqual(["b@x.com", "c@x.com"]);
+      });
+    });
   });
 
   describe("sendScheduledNotifications", () => {

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -170,6 +170,63 @@ describe('test changed functions', () => {
             expect(checkDerivedVariablesSpy).toHaveBeenCalledWith('participant-token', siteCode);
         });
 
+        it('records the participant update even when the site-notification email throws (best-effort policy)', async () => {
+            vi.spyOn(firestore, 'getParticipantData').mockResolvedValue({
+                id: 'participant-doc',
+                data: {
+                    'Connect_ID': '1234567890',
+                    [fieldMapping.healthCareProvider]: siteCode,
+                },
+            });
+            const updateParticipantDataByDocIdSpy = vi.spyOn(firestore, 'updateParticipantDataByDocId').mockResolvedValue();
+            vi.spyOn(validation, 'checkDerivedVariables').mockResolvedValue();
+            vi.spyOn(firestore, 'getSiteEmail').mockResolvedValue('site-and-cc-same@example.com');
+
+            const siteNotifications = require('../../utils/siteNotifications');
+            const sendGridErr = Object.assign(new Error('Bad Request'), { code: 400 });
+            const handleSiteNotificationsSpy = vi.spyOn(siteNotifications, 'handleSiteNotifications')
+                .mockRejectedValue(sendGridErr);
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            // Payload that triggers the data-destruction site notification path
+            // (all three: destroyData + withdrawConsent + revokeHIPAA = yes).
+            const req = createRequest({
+                data: [{
+                    token: 'participant-token',
+                    '831041022': 353358909,  // destroyData = yes
+                    '747006172': 353358909,  // withdrawConsent = yes
+                    '773707518': 353358909,  // revokeHIPAA = yes
+                }],
+            });
+            const res = createResponse();
+
+            await updateParticipantData(req, res, authObj);
+
+            // The site notification was attempted (and threw under the hood).
+            expect(handleSiteNotificationsSpy).toHaveBeenCalledTimes(1);
+
+            // The participant write STILL happened — that's the whole point of best-effort.
+            expect(updateParticipantDataByDocIdSpy).toHaveBeenCalledTimes(1);
+
+            // The endpoint returns success (200), not 500/206 from a propagated email failure.
+            expect(res.statusCode).toBe(200);
+
+            // The failure was logged with the "non-fatal" structured marker for ops alerts.
+            const nonFatalLog = consoleErrorSpy.mock.calls.find(([msg]) =>
+                typeof msg === 'string' && msg.includes('Site notification failed (non-fatal)')
+            );
+            expect(nonFatalLog).toBeDefined();
+            // Structured context should carry the concept + the SendGrid error code/message.
+            const logContext = nonFatalLog[1];
+            expect(logContext).toMatchObject({
+                concept: '831041022',
+                code: 400,
+                error: 'Bad Request',
+            });
+
+            consoleErrorSpy.mockRestore();
+        });
+
         it('adds a reinvitation timestamp for eligible active recruits', async () => {
             vi.spyOn(firestore, 'getParticipantData').mockResolvedValue({
                 id: 'participant-doc',

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1,5 +1,5 @@
 const admin = require('firebase-admin');
-const { Transaction, FieldPath, FieldValue, Filter } = require('firebase-admin/firestore');
+const { Transaction, FieldPath, FieldValue, Filter, Timestamp } = require('firebase-admin/firestore');
 admin.initializeApp();
 const storage = admin.storage();
 const db = admin.firestore();
@@ -3564,6 +3564,11 @@ const BULK_RUN_BATCH_COLLECTION = "batches";
 const BULK_RUN_TERMINAL_STATUSES = new Set(["complete", "failed"]);
 const DEFAULT_BULK_BATCH_ATTEMPT_DURATION_MS = 30 * 60 * 1000;
 
+// Retention for bulk run history. Run docs and their `batches` subdocs: 45 day TTL policy using `expiresAt` Timestamp. 
+const BULK_RUN_TTL_DAYS = 45;
+const BULK_RUN_TTL_MS = BULK_RUN_TTL_DAYS * 24 * 60 * 60 * 1000;
+const buildBulkRunExpiresAt = () => Timestamp.fromMillis(Date.now() + BULK_RUN_TTL_MS);
+
 const getBulkRunRef = (runId) => db.collection(BULK_RUN_COLLECTION).doc(runId);
 const getBulkRunBatchRef = (runId, batchId) =>
   getBulkRunRef(runId).collection(BULK_RUN_BATCH_COLLECTION).doc(batchId);
@@ -3687,6 +3692,8 @@ const saveBulkNotificationRunPlan = async ({
   }
 
   const now = new Date().toISOString();
+  // Shared expiresAt for the run doc and its batch subdocs (Firestore TTL policy).
+  const expiresAt = buildBulkRunExpiresAt();
   const runRef = getBulkRunRef(runDoc.id);
   const batchIds = batchDocs.map((batchDoc) => batchDoc.id).filter(Boolean);
   const batchIdsByLane = batchDocs.reduce((acc, batchDoc) => {
@@ -3707,6 +3714,7 @@ const saveBulkNotificationRunPlan = async ({
     batchCount: batchIds.length,
     status: runDoc.status || "planned",
     updatedAt: now,
+    expiresAt,
   }, { merge: true });
 
   for (let i = 0; i < batchDocs.length; i += 450) {
@@ -3720,6 +3728,7 @@ const saveBulkNotificationRunPlan = async ({
         runId: runDoc.id,
         status: batchDoc.status || "planned",
         updatedAt: now,
+        expiresAt,
       }, { merge: true });
     }
     await batch.commit();

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -21,7 +21,7 @@ let isTwilioSetup = false;
 let twilioAuthToken = "";
 // Per-instance guard. Cloud Functions Gen2 may spawn multiple instances, each with its own copy of this flag.
 // Coordination across instances relies on three layers:
-//    - (1) `sendScheduledNotificationsGen2` is configured with `--ingress-settings=internal-only` so only Cloud Scheduler can invoke it.
+//    - (1) `sendScheduledNotifications` is deployed with `--ingress=internal` so only Cloud Scheduler can invoke it.
 //    - (2) Cloud Scheduler is configured to fire once per day.
 //    - (3) the per-recipient `notifications` doc state machine and the per-batch `notificationBulkRuns` queued markers prevent duplicate sends even if a second invocation slips through.
 // per-recipient `notifications` doc state machine and the per-batch `notificationBulkRuns` queued markers prevent duplicate sends even if a
@@ -40,6 +40,66 @@ const BULK_LANE_CONFIG = Object.freeze({
   }),
 });
 const BULK_TASK_DISPATCH_DEADLINE_SECONDS = 1800;
+const BULK_WORKER_URI_SETTINGS_KEYS = Object.freeze({
+  [BULK_LANE_DEFAULT]: "bulkWorkerUriDefault",
+  [BULK_LANE_MICROSOFT]: "bulkWorkerUriMicrosoft",
+});
+
+// Validates a bulk worker URI before it's passed to Cloud Tasks.
+const validateBulkWorkerUri = (uri, lane, source) => {
+  if (typeof uri !== "string") {
+    throw new Error(
+      `Bulk worker URI for lane "${lane}" from ${source} must be a string. Got: ${typeof uri} (${JSON.stringify(uri)}).`,
+    );
+  }
+  const trimmed = uri.trim();
+  if (!trimmed) {
+    throw new Error(`Bulk worker URI for lane "${lane}" from ${source} is empty.`);
+  }
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (err) {
+    throw new Error(`Bulk worker URI for lane "${lane}" from ${source} is not a valid URL: "${uri}". ${err.message}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Bulk worker URI for lane "${lane}" from ${source} must use https. Got: "${uri}".`);
+  }
+  if (!parsed.hostname.endsWith(".run.app")) {
+    console.warn(`Bulk worker URI for lane "${lane}" from ${source} hostname "${parsed.hostname}" does not end with ".run.app". Verify this is the correct Cloud Run URL.`);
+  }
+  
+  return trimmed;
+};
+
+const buildBulkWorkerUri = (lane, notificationSettings = {}) => {
+  const envVarName = `BULK_WORKER_URI_${String(lane).toUpperCase()}`;
+  const envOverride = process.env[envVarName];
+  if (envOverride) {
+    return validateBulkWorkerUri(envOverride, lane, `${envVarName} env var`);
+  }
+
+  const settingsKey = BULK_WORKER_URI_SETTINGS_KEYS[lane];
+  if (!settingsKey) {
+    throw new Error(
+      `Unknown bulk lane: "${lane}". Expected one of: ${Object.keys(BULK_WORKER_URI_SETTINGS_KEYS).join(", ")}.`,
+    );
+  }
+  const uri = notificationSettings[settingsKey];
+  if (!uri) {
+    const project = process.env.GCLOUD_PROJECT || "(GCLOUD_PROJECT unset)";
+    const serviceName = `processnotificationbatchbulk${lane}`;
+    throw new Error(
+      `Bulk worker URI not configured for lane "${lane}". ` +
+      `Expected appSettings.notifications.${settingsKey} (on the Firestore doc where appName == "connectFaas") ` +
+      `to contain the Cloud Run URL for service "${serviceName}" in project "${project}". ` +
+      `Look it up with: gcloud run services describe ${serviceName} --region=us-central1 --project=${project} --format='value(status.url)' ` +
+      `and write the result into Firestore. See the "Pre-deploy: bulk worker URI configuration" section of the rollout doc.`,
+    );
+  }
+  return validateBulkWorkerUri(uri, lane, `appSettings.notifications.${settingsKey}`);
+};
+
 // Firestore-visible attempt lock duration. Kept much shorter than the Cloud Tasks dispatch deadline so a crashed attempt's lock expires before
 // the queue's max-attempts (5) × min-backoff (60s) retry budget is exhausted.
 // A successful send completes in seconds. This value only needs to cover slow batches.
@@ -63,6 +123,17 @@ const DEFAULT_NOTIFICATION_SETTINGS = Object.freeze({
   microsoftBulkDomains: Object.freeze(["outlook.com", "hotmail.com", "live.com", "msn.com"]),
   sendRetryMax: 5,                          // Maximum number of retries for send operations.
   emailBatchDelayMs: 1000,                  // Delay between email batches to avoid overwhelming the API. Used for transactional mail stream.
+  // Bulk Cloud Tasks worker dispatch URIs.
+  // Gotcha warning: The Firebase Admin SDK auto-derives a URL
+  // assuming the firebase-deploy pattern, but our workers are deployed via
+  // `gcloud run deploy --function=` and live at Cloud Run URLs that include a
+  // per-project hash. Populate these per environment in the Firestore appSettings
+  // doc (appName == "connectFaas") with the output of:
+  //   gcloud run services describe processnotificationbatchbulkdefault \
+  //     --region=us-central1 --project=<PROJECT> --format='value(status.url)'
+  // (and the equivalent for processnotificationbatchbulkmicrosoft).
+  bulkWorkerUriDefault: null,
+  bulkWorkerUriMicrosoft: null,
 });
 // HMAC signature for unsubscribe URLs prevents unauthorized suppression of arbitrary emails.
 // Secret is resolved from Secret Manager via resolveUnsubscribeSecret() before use.
@@ -227,6 +298,14 @@ const getNotificationDeliverySettings = async () => {
       notifications.emailBatchDelayMs,
       DEFAULT_NOTIFICATION_SETTINGS.emailBatchDelayMs,
     ),
+    bulkWorkerUriDefault:
+      typeof notifications.bulkWorkerUriDefault === "string"
+        ? notifications.bulkWorkerUriDefault
+        : DEFAULT_NOTIFICATION_SETTINGS.bulkWorkerUriDefault,
+    bulkWorkerUriMicrosoft:
+      typeof notifications.bulkWorkerUriMicrosoft === "string"
+        ? notifications.bulkWorkerUriMicrosoft
+        : DEFAULT_NOTIFICATION_SETTINGS.bulkWorkerUriMicrosoft,
   };
 };
 
@@ -1510,6 +1589,7 @@ const enqueuePlannedBulkBatchTask = async ({
   queue,
   run,
   batchDoc,
+  notificationSettings,
 }) => {
   const taskId = buildPlannedBulkNotificationTaskId(run.id, batchDoc.lane, batchDoc.batchNumber);
   const payload = {
@@ -1520,11 +1600,23 @@ const enqueuePlannedBulkBatchTask = async ({
     runDateKey: run.runDateKey,
     runSequence: run.runSequence,
   };
+
+  // Resolve the dispatch URI before calling queue.enqueue so a misconfigured appSettings field surfaces in our logs, rather
+  // than later as a silent 404 inside Cloud Tasks. Any throw here is fatal for this task.
+  let uri;
+  try {
+    uri = buildBulkWorkerUri(batchDoc.lane, notificationSettings);
+  } catch (error) {
+    console.error(`Cannot enqueue planned bulk task ${taskId} (runId=${run.id}, batchId=${batchDoc.id}, lane=${batchDoc.lane}): ${error.message}`);
+    throw error;
+  }
+
   try {
     await queue.enqueue(payload, {
       scheduleDelaySeconds: batchDoc.scheduleDelaySeconds || 0,
       dispatchDeadlineSeconds: BULK_TASK_DISPATCH_DEADLINE_SECONDS,
       id: taskId,
+      uri,
     });
     return { taskId, alreadyExisted: false };
   } catch (error) {
@@ -1532,6 +1624,9 @@ const enqueuePlannedBulkBatchTask = async ({
       console.log(`Planned bulk notification task already exists: ${taskId}`);
       return { taskId, alreadyExisted: true };
     }
+    // Include the URI we tried in the error log. If the dispatch fails due to a wrong URL,
+    // this is the breadcrumb that ties the task identity to the URL used, which Cloud Tasks does not surface.
+    console.error(`Failed to enqueue planned bulk task ${taskId} (runId=${run.id}, batchId=${batchDoc.id}, lane=${batchDoc.lane}, uri=${uri}): ${error.message || error.code || "(no message)"}`);
     throw error;
   }
 };
@@ -1539,6 +1634,7 @@ const enqueuePlannedBulkBatchTask = async ({
 const enqueueBulkRunPlanTasks = async ({
   run,
   batchDocs,
+  notificationSettings,
 }) => {
   const { getFunctions } = require("firebase-admin/functions");
   const functions = getFunctions();
@@ -1554,7 +1650,7 @@ const enqueueBulkRunPlanTasks = async ({
   const results = await runWithConcurrency(candidates, ENQUEUE_CONCURRENCY, async (batchDoc) => {
     const queueName = getPlannedBulkTaskQueueName(batchDoc.lane);
     const queue = functions.taskQueue(queueName);
-    const { taskId, alreadyExisted } = await enqueuePlannedBulkBatchTask({ queue, run, batchDoc });
+    const { taskId, alreadyExisted } = await enqueuePlannedBulkBatchTask({ queue, run, batchDoc, notificationSettings });
     const scheduleDelaySeconds = batchDoc.scheduleDelaySeconds || 0;
     // On a fresh enqueue we record the calculated scheduledFor.
     // On resume (Cloud Tasks already has the task from a prior partial run),
@@ -1707,6 +1803,7 @@ async function sendScheduledNotifications(req, res) {
           const enqueued = await enqueueBulkRunPlanTasks({
             run,
             batchDocs: plannedBatches,
+            notificationSettings,
           });
           enqueuedBulkTaskCount += enqueued.length;
           console.log(
@@ -3134,4 +3231,6 @@ module.exports = {
   processNotificationBatchBulkDefault,
   processNotificationBatchBulkMicrosoft,
   processPlannedBulkNotificationBatch,
+  buildBulkWorkerUri,
+  validateBulkWorkerUri,
 };

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -68,7 +68,7 @@ const validateBulkWorkerUri = (uri, lane, source) => {
   if (!parsed.hostname.endsWith(".run.app")) {
     console.warn(`Bulk worker URI for lane "${lane}" from ${source} hostname "${parsed.hostname}" does not end with ".run.app". Verify this is the correct Cloud Run URL.`);
   }
-  
+
   return trimmed;
 };
 
@@ -1624,8 +1624,7 @@ const enqueuePlannedBulkBatchTask = async ({
       console.log(`Planned bulk notification task already exists: ${taskId}`);
       return { taskId, alreadyExisted: true };
     }
-    // Include the URI we tried in the error log. If the dispatch fails due to a wrong URL,
-    // this is the breadcrumb that ties the task identity to the URL used, which Cloud Tasks does not surface.
+    // If the dispatch fails due to a wrong URL, this is the breadcrumb that ties the task identity to the URL used (Cloud Tasks does not surface).
     console.error(`Failed to enqueue planned bulk task ${taskId} (runId=${run.id}, batchId=${batchDoc.id}, lane=${batchDoc.lane}, uri=${uri}): ${error.message || error.code || "(no message)"}`);
     throw error;
   }

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1021,6 +1021,38 @@ const retrieveNotifications = async (req, res, uid) => {
   }
 };
 
+/**
+ * Normalize an email address for duplicate comparison.
+ */
+const normalizeEmailForCompare = (email) => {
+    if (typeof email !== "string") return null;
+    const trimmed = email.trim();
+    return trimmed ? trimmed.toLowerCase() : null;
+};
+
+/**
+ * Remove any CC entry that duplicates the primary `to` recipient. SendGrid
+ * rejects a personalization where the same address appears in both `to` and
+ * `cc`/`bcc` ("Each email address in the personalization block should be
+ * unique").
+ */
+const dedupeCcAgainstTo = (cc, toEmail) => {
+    if (!cc) return undefined;
+    const toKey = normalizeEmailForCompare(toEmail);
+
+    if (Array.isArray(cc)) {
+        const filtered = cc.filter((entry) => {
+            const key = normalizeEmailForCompare(entry);
+            return key && key !== toKey;
+        });
+        return filtered.length > 0 ? filtered : undefined;
+    }
+
+    const ccKey = normalizeEmailForCompare(cc);
+    if (!ccKey || ccKey === toKey) return undefined;
+    return cc;
+};
+
 const sendEmail = async (emailTo, messageSubject, html, cc) => {
     const notificationSettings = await getNotificationDeliverySettings();
     const msg = {
@@ -1032,12 +1064,29 @@ const sendEmail = async (emailTo, messageSubject, html, cc) => {
         subject: messageSubject,
         html: html,
     };
-    if(cc) msg.cc = cc;
+    const dedupedCc = dedupeCcAgainstTo(cc, emailTo);
+    if (dedupedCc) msg.cc = dedupedCc;
     msg.text = htmlToPlaintext(html);
     try {
         await sendViaSendGrid(msg, { logLabel: "sendEmail", notificationSettings });
     } catch (error) {
-        console.error("Email send failed:", { message: error?.message, code: error?.code });
+        let bodyDetail;
+        try {
+            bodyDetail = error?.response?.body
+                ? JSON.stringify(error.response.body)
+                : undefined;
+        } catch {
+            bodyDetail = "<unserializable response body>";
+        }
+        console.error("Email send failed:", {
+            message: error?.message,
+            code: error?.code,
+            to: emailTo,
+            cc: cc || undefined,
+            from: msg.from?.email,
+            subject: messageSubject,
+            body: bodyDetail,
+        });
         throw error;
     }
 }
@@ -3070,6 +3119,7 @@ module.exports = {
   retrieveNotificationSchema,
   getParticipantNotification,
   sendEmail,
+  dedupeCcAgainstTo,
   getSiteNotification,
   sendEmailLink,
   dryRunNotificationSchema,

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -183,6 +183,25 @@ const siteNotificationsHandler = async (Connect_ID, concept, siteCode, obj) => {
     await handleSiteNotifications(Connect_ID, concept, siteEmail, obj.id, obj.acronym, siteCode);
 }
 
+/**
+ * Best-effort wrapper around siteNotificationsHandler. Site notifications are
+ * informational and should not block a participant's status update (destruction request, withdraw,
+ * revoke, deceased report) must succeed even if the notification email fails.
+ */
+const trySiteNotification = async (Connect_ID, concept, siteCode, obj) => {
+    try {
+        await siteNotificationsHandler(Connect_ID, concept, siteCode, obj);
+    } catch (error) {
+        console.error("Site notification failed (non-fatal). Participant update will still proceed.", {
+            connectId: Connect_ID,
+            concept,
+            siteCode,
+            error: error?.message,
+            code: error?.code,
+        });
+    }
+}
+
 const updateParticipantData = async (req, res, authObj) => {
     const { getParticipantData, updateParticipantDataByDocId, writeBirthdayCard, writeCancerOccurrences } = require('./firestore');
     const { checkForQueryFields, flattenObject, initializeTimestamps, userProfileHistoryKeys } = require('./shared');
@@ -302,16 +321,16 @@ const updateParticipantData = async (req, res, authObj) => {
 
         // Handle site notifications
         if(dataObj['831041022'] && dataObj['747006172'] && dataObj['773707518'] && dataObj['831041022'] === 353358909 && dataObj['747006172'] === 353358909 && dataObj['773707518'] === 353358909){ // Data Destruction
-            await siteNotificationsHandler(docData['Connect_ID'], '831041022', docData['827220437'], obj);
+            await trySiteNotification(docData['Connect_ID'], '831041022', docData['827220437'], obj);
         }
         else if (dataObj['747006172'] && dataObj['773707518'] && dataObj['747006172'] === 353358909 && dataObj['773707518'] === 353358909) { // Withdraw Consent
-            await siteNotificationsHandler(docData['Connect_ID'], '747006172', docData['827220437'], obj);
+            await trySiteNotification(docData['Connect_ID'], '747006172', docData['827220437'], obj);
         }
         else if(dataObj['773707518'] && dataObj['773707518'] === 353358909) { // Revocation only email
-            await siteNotificationsHandler(docData['Connect_ID'], '773707518', docData['827220437'], obj);
+            await trySiteNotification(docData['Connect_ID'], '773707518', docData['827220437'], obj);
         }
         else if (dataObj['987563196'] && dataObj['987563196'] === 353358909) {
-            await siteNotificationsHandler(docData['Connect_ID'], '987563196', docData['827220437'], obj);
+            await trySiteNotification(docData['Connect_ID'], '987563196', docData['827220437'], obj);
         }
         
         // Flatten dataObj and docData for comparison & validation with JSON file.


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/1595 & https://github.com/episphere/connect/issues/1599

Handle matching to & cc/bcc edge case:
•Handle the dev case where `to` and `cc/bcc` match (dedupe them).
•Don't allow a failed notification to cause a failed update.
•Improve error reporting on failed email notifications.

Update Cloud Tasks handling
Add TTL using `expiresAt` with 45 day cleanup to `notificationBulkRuns` and their `batches` subcollections (the documents that track bulk notification runs through their lifecycle).