### PR TITLE
Geocode API

### DIFF
--- a/config/yaml/geocodedAddresses.yaml
+++ b/config/yaml/geocodedAddresses.yaml
@@ -1,0 +1,40 @@
+steps:
+
+
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run',
+    'deploy',
+    '${_SERVICE}',
+    '--region=${_REGION}',
+    '--source=${_SOURCE}',
+    '--function=${_FUNCTION}',
+    '--base-image=${_BASE_IMAGE}',
+    '--memory=${_MEMORY}',
+    '--timeout=${_TIMEOUT}',
+    '--allow-unauthenticated',
+    '--env-vars-file=${_VARIABLES}'
+  ]
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run',
+    'services',
+    'add-iam-policy-binding',
+    '${_SERVICE}',
+    '--region=${_REGION}',
+    '--member=${_MEMBER}',
+    '--role=${_ROLE}'
+  ]
+
+substitutions:
+  _BASE_IMAGE: us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs20
+  _FUNCTION: geocodedAddresses
+  _MEMBER: allUsers
+  _MEMORY: 1024Mi
+  _REGION: us-central1
+  _ROLE: roles/run.invoker
+  _SERVICE: geocodedaddresses
+  _SOURCE: .
+  _TIMEOUT: 240s

--- a/config/yaml/geocodedAddresses.yaml
+++ b/config/yaml/geocodedAddresses.yaml
@@ -14,7 +14,6 @@ steps:
     '--memory=${_MEMORY}',
     '--timeout=${_TIMEOUT}',
     '--allow-unauthenticated',
-    '--env-vars-file=${_VARIABLES}'
   ]
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -29,7 +28,7 @@ steps:
   ]
 
 substitutions:
-  _BASE_IMAGE: us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs20
+  _BASE_IMAGE: us-central1-docker.pkg.dev/serverless-runtimes/google-24-full/runtimes/nodejs24
   _FUNCTION: geocodedAddresses
   _MEMBER: allUsers
   _MEMORY: 1024Mi

--- a/geocodedAddresses.json
+++ b/geocodedAddresses.json
@@ -1,0 +1,74 @@
+{
+    "758212868": {
+        "dataType": "number",
+        "maxLength": 5
+    },
+    "403294814": {
+        "dataType": "number",
+        "maxLength": 4
+    },
+    "826796611": {
+        "dataType": "string",
+        "maxLength": 38
+    },
+    "565540989": {
+        "dataType": "string",
+        "maxLength": 50
+    },
+    "266861817": {
+        "dataType": "number",
+        "maxLength": 5
+    },
+    "202200799": {
+        "dataType": "string",
+        "maxLength": 2
+    },
+    "743072841": {
+        "dataType": "string",
+        "maxLength": 26
+    },
+    "845922276": {
+        "dataType": "string",
+        "maxLength": 22
+    },
+    "801579513": {
+        "dataType": "string",
+        "maxLength": 13
+    },
+    "680977535": {
+        "dataType": "string",
+        "maxLength": 13
+    },
+    "951694129": {
+        "dataType": "string",
+        "maxLength": 14
+    },
+    "123987148": {
+        "dataType": "number",
+        "values": [104430631, 353358909]
+    },
+    "473216280": {
+        "dataType": "string",
+        "maxLength": 9
+    },
+    "881949895": {
+        "dataType": "number",
+        "maxLength": 11
+    },
+    "552433369": {
+        "dataType": "string",
+        "maxLength": 20
+    },
+    "916814781": {
+        "dataType": "string",
+        "maxLength": 30
+    },
+    "625954624": {
+        "dataType": "string",
+        "maxLength": 32
+    },
+    "185323683": {
+        "dataType": "string",
+        "maxLength": 17
+    }
+}

--- a/geocodedAddresses.json
+++ b/geocodedAddresses.json
@@ -1,7 +1,8 @@
 {
     "758212868": {
         "dataType": "number",
-        "maxLength": 5
+        "maxLength": 6,
+        "required": true
     },
     "403294814": {
         "dataType": "number",
@@ -40,19 +41,19 @@
         "maxLength": 13
     },
     "951694129": {
-        "dataType": "string",
-        "maxLength": 14
+        "dataType": "number",
+        "values": [728662578, 717366608, 495372270, 703385619, 343111826, 503218834]
     },
     "123987148": {
         "dataType": "number",
         "values": [104430631, 353358909]
     },
     "473216280": {
-        "dataType": "string",
-        "maxLength": 9
+        "dataType": "number",
+        "values": [768887460, 926338735]
     },
     "881949895": {
-        "dataType": "number",
+        "dataType": "string",
         "maxLength": 11
     },
     "552433369": {
@@ -65,7 +66,8 @@
     },
     "625954624": {
         "dataType": "string",
-        "maxLength": 32
+        "maxLength": 32,
+        "required": true
     },
     "185323683": {
         "dataType": "string",

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const {onRequest} = require("firebase-functions/v2/https");
 const { onTaskDispatched } = require("firebase-functions/v2/tasks");
 const { getToken } = require('./utils/validation');
 const { getFilteredParticipants, getParticipants, identifyParticipant } = require('./utils/submission');
-const { submitParticipantsData, updateParticipantData, getBigQueryData } = require('./utils/sites');
+const { submitParticipantsData, updateParticipantData, getBigQueryData, geocodedAddresses } = require('./utils/sites');
 const { sendScheduledNotifications, processNotificationBatchBulkDefault, processNotificationBatchBulkMicrosoft } = require('./utils/notifications');
 const { connectApp } = require('./utils/connectApp');
 const { biospecimenAPIs } = require('./utils/biospecimen');
@@ -26,6 +26,7 @@ exports.identifyParticipant = identifyParticipant;
 exports.submitParticipantsData = submitParticipantsData;
 exports.updateParticipantData = updateParticipantData;
 exports.getBigQueryData = getBigQueryData;
+exports.geocodedAddresses = geocodedAddresses;
 
 // End-Point for Site Manager Dashboard
 exports.dashboard = dashboard;

--- a/test/unit/apiEndpoints.test.js
+++ b/test/unit/apiEndpoints.test.js
@@ -165,7 +165,8 @@ describe('API Endpoint Method Guards', () => {
         }
     });
 
-    describe('geocodedAddresses authorization', () => {
+    // TODO: Re-enable when the geocodedAddresses 503 shutdown is removed (October 2026).
+    describe.skip('geocodedAddresses authorization', () => {
         it('should reject unauthenticated requests with 401', async () => {
             const res = await invoke(api.geocodedAddresses, 'POST', {
                 body: { data: [{ Connect_ID: 123 }] },

--- a/test/unit/apiEndpoints.test.js
+++ b/test/unit/apiEndpoints.test.js
@@ -202,7 +202,7 @@ describe('API Endpoint Method Guards', () => {
             expect(res.statusCode).toBe(400);
         });
 
-        it('should reject requests exceeding 1000 records with 400', async () => {
+        it('should reject requests exceeding 500 records with 400', async () => {
             const shared = require('../../utils/shared');
             vi.spyOn(shared, 'APIAuthorization').mockResolvedValue({
                 acronym: 'NORC',
@@ -211,10 +211,10 @@ describe('API Endpoint Method Guards', () => {
 
             const res = await invoke(api.geocodedAddresses, 'POST', {
                 headers: { authorization: 'Bearer fake-token' },
-                body: { data: Array(1001).fill({ Connect_ID: 123 }) },
+                body: { data: Array(501).fill({ Connect_ID: 123 }) },
             });
             expect(res.statusCode).toBe(400);
-            expect(res._getJSONData().message).toContain('1000');
+            expect(res._getJSONData().message).toContain('500');
         });
     });
 

--- a/test/unit/apiEndpoints.test.js
+++ b/test/unit/apiEndpoints.test.js
@@ -16,7 +16,7 @@ beforeAll(() => {
     const { incentiveCompleted, eligibleForIncentive } = require('../../utils/incentive');
     const { getToken } = require('../../utils/validation');
     const { getFilteredParticipants, getParticipants, identifyParticipant } = require('../../utils/submission');
-    const { submitParticipantsData, updateParticipantData, getBigQueryData } = require('../../utils/sites');
+    const { submitParticipantsData, updateParticipantData, getBigQueryData, geocodedAddresses } = require('../../utils/sites');
     const { dashboard } = require('../../utils/dashboard');
     const { connectApp } = require('../../utils/connectApp');
     const { biospecimenAPIs } = require('../../utils/biospecimen');
@@ -37,6 +37,7 @@ beforeAll(() => {
         submitParticipantsData,
         updateParticipantData,
         getBigQueryData,
+        geocodedAddresses,
         getParticipantNotification: notifications.getParticipantNotification,
         dashboard,
         app: connectApp,
@@ -93,6 +94,7 @@ describe('API Endpoint Method Guards', () => {
             ['biospecimen', () => api.biospecimen],
             ['heartbeat', () => api.heartbeat],
             ['physicalActivity', () => api.physicalActivity],
+            ['geocodedAddresses', () => api.geocodedAddresses],
         ];
 
         for (const [name, getHandler] of optionsCases) {
@@ -117,6 +119,7 @@ describe('API Endpoint Method Guards', () => {
             ['getBigQueryData', () => api.getBigQueryData, 'POST', 'Only GET requests are accepted!'],
             ['webhook', () => api.webhook, 'GET', 'Only POST requests are accepted!'],
             ['auditDataDestruction', () => api.auditDataDestruction, 'GET', 'Method not allowed. Use POST.'],
+            ['geocodedAddresses', () => api.geocodedAddresses, 'GET', 'Only POST requests are accepted!'],
         ];
 
         for (const [name, getHandler, method, expectedMessage] of methodCases) {
@@ -160,6 +163,59 @@ describe('API Endpoint Method Guards', () => {
                 expect(res.statusCode).toBe(401);
             });
         }
+    });
+
+    describe('geocodedAddresses authorization', () => {
+        it('should reject unauthenticated requests with 401', async () => {
+            const res = await invoke(api.geocodedAddresses, 'POST', {
+                body: { data: [{ Connect_ID: 123 }] },
+            });
+            expect(res.statusCode).toBe(401);
+        });
+
+        it('should reject non-NORC sites with 403', async () => {
+            const shared = require('../../utils/shared');
+            vi.spyOn(shared, 'APIAuthorization').mockResolvedValue({
+                acronym: 'HP',
+                siteCode: 531629870,
+            });
+
+            const res = await invoke(api.geocodedAddresses, 'POST', {
+                headers: { authorization: 'Bearer fake-token' },
+                body: { data: [{ Connect_ID: 123 }] },
+            });
+            expect(res.statusCode).toBe(403);
+            expect(res._getJSONData().message).toBe('You are not authorized!');
+        });
+
+        it('should reject requests with no data array with 400', async () => {
+            const shared = require('../../utils/shared');
+            vi.spyOn(shared, 'APIAuthorization').mockResolvedValue({
+                acronym: 'NORC',
+                siteCode: 123456,
+            });
+
+            const res = await invoke(api.geocodedAddresses, 'POST', {
+                headers: { authorization: 'Bearer fake-token' },
+                body: {},
+            });
+            expect(res.statusCode).toBe(400);
+        });
+
+        it('should reject requests exceeding 1000 records with 400', async () => {
+            const shared = require('../../utils/shared');
+            vi.spyOn(shared, 'APIAuthorization').mockResolvedValue({
+                acronym: 'NORC',
+                siteCode: 123456,
+            });
+
+            const res = await invoke(api.geocodedAddresses, 'POST', {
+                headers: { authorization: 'Bearer fake-token' },
+                body: { data: Array(1001).fill({ Connect_ID: 123 }) },
+            });
+            expect(res.statusCode).toBe(400);
+            expect(res._getJSONData().message).toContain('1000');
+        });
     });
 
     describe('heartbeat success path', () => {

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -262,7 +262,8 @@ describe('test changed functions', () => {
     });
 });
 
-describe('geocodedAddresses', () => {
+// TODO: Re-enable when the geocodedAddresses 503 shutdown is removed (October 2026).
+describe.skip('geocodedAddresses', () => {
     const norcAuth = { acronym: 'NORC', siteCode: 123456 };
 
     // Valid values for the two required fields (758212868 and 625954624).

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -277,12 +277,19 @@ describe('geocodedAddresses', () => {
 
     const createResponse = () => httpMocks.createResponse();
 
+    // Build the Map that getParticipantsDataByConnectIds resolves to, keyed by Connect_ID.
+    const participantMapOf = (...records) => {
+        const map = new Map();
+        for (const record of records) map.set(record.data.Connect_ID, record);
+        return map;
+    };
+
     it('returns 200 and stores valid rows', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'participant-doc',
             data: { Connect_ID: 1234567890 },
-        });
+        }));
         const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
 
         const req = createGeoRequest({
@@ -311,12 +318,11 @@ describe('geocodedAddresses', () => {
 
     it('returns 206 with mixed valid and invalid rows (partial acceptance)', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID')
-            .mockResolvedValueOnce({
-                id: 'doc-1',
-                data: { Connect_ID: 1111111111 },
-            })
-            .mockResolvedValueOnce(null);
+        // Only 1111111111 exists; 9999999999 is absent from the map.
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        }));
         const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
 
         const req = createGeoRequest({
@@ -339,6 +345,7 @@ describe('geocodedAddresses', () => {
 
     it('rejects rows with missing Connect_ID', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf());
 
         const req = createGeoRequest({
             data: [{ '202200799': 'CA' }],
@@ -354,13 +361,13 @@ describe('geocodedAddresses', () => {
 
     it('rejects rows for destroyed participants', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-destroyed',
             data: {
                 Connect_ID: 5555555555,
                 [fieldMapping.participantMap.dataHasBeenDestroyed]: fieldMapping.yes,
             },
-        });
+        }));
 
         const req = createGeoRequest({
             data: [{ Connect_ID: 5555555555, '202200799': 'TX' }],
@@ -375,10 +382,10 @@ describe('geocodedAddresses', () => {
 
     it('rejects rows with validation errors (wrong type)', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
 
         const req = createGeoRequest({
             data: [{
@@ -397,10 +404,10 @@ describe('geocodedAddresses', () => {
 
     it('rejects rows with validation errors (exceeds maxLength)', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
 
         const req = createGeoRequest({
             data: [{
@@ -414,15 +421,37 @@ describe('geocodedAddresses', () => {
 
         expect(res.statusCode).toBe(206);
         const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
-        expect(errors[0]).toContain('at most 2 characters');
+        expect(errors[0]).toContain('less than 2 characters');
+    });
+
+    it('rejects rows with number fields exceeding maxLength', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        }));
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '758212868': 123456, // rule: number, maxLength 5 -> 6 digits is too long
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
+        expect(errors[0]).toContain('less than 5 digits');
     });
 
     it('rejects rows with unknown concept IDs', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
 
         const req = createGeoRequest({
             data: [{
@@ -441,10 +470,10 @@ describe('geocodedAddresses', () => {
 
     it('skips blank fields without error and stores non-blank fields', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
         const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
 
         const req = createGeoRequest({
@@ -468,10 +497,10 @@ describe('geocodedAddresses', () => {
 
     it('returns 500 if Firestore write fails', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
         vi.spyOn(firestore, 'writeGeocodedAddresses').mockRejectedValue(new Error('Firestore unavailable'));
 
         const req = createGeoRequest({
@@ -486,10 +515,10 @@ describe('geocodedAddresses', () => {
 
     it('rejects rows where all fields are blank', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
 
         const req = createGeoRequest({
             data: [{
@@ -506,10 +535,10 @@ describe('geocodedAddresses', () => {
         expect(res._getJSONData().results[0]['Invalid Request'].Errors).toBe('No non-blank fields provided.');
     });
 
-    it('handles getParticipantDataByConnectID throwing (e.g. duplicate Connect_ID)', async () => {
+    it('returns 500 if the participant batch lookup fails', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockRejectedValue(
-            new Error('Multiple participants found with connectId 1111111111')
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockRejectedValue(
+            new Error('Firestore unavailable')
         );
 
         const req = createGeoRequest({
@@ -519,17 +548,15 @@ describe('geocodedAddresses', () => {
 
         await geocodedAddresses(req, res);
 
-        expect(res.statusCode).toBe(206);
-        const result = res._getJSONData().results[0];
-        expect(result['Server Error'].Errors).toContain('Multiple participants found');
+        expect(res.statusCode).toBe(500);
     });
 
     it('normalizes Connect_ID to number for consistent hashing', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
-        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
             id: 'doc-1',
             data: { Connect_ID: 1111111111 },
-        });
+        }));
         const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
 
         const req = createGeoRequest({

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -16,6 +16,7 @@ const authObj = {
 let submitParticipantsData;
 let updateParticipantData;
 let updateRecruit;
+let geocodedAddresses;
 let firestore;
 let shared;
 let validation;
@@ -30,6 +31,7 @@ beforeAll(() => {
         submitParticipantsData,
         updateParticipantData,
         updateRecruit,
+        geocodedAddresses,
     } = require('../../utils/sites'));
     firestore = require('../../utils/firestore');
     shared = require('../../utils/shared');
@@ -257,5 +259,228 @@ describe('test changed functions', () => {
             const updates = updateParticipantDataByDocIdSpy.mock.calls[0][1];
             expect(Number.isNaN(Date.parse(updates[fieldMapping.reinvitationTimestamp]))).toBe(false);
         });
+    });
+});
+
+describe('geocodedAddresses', () => {
+    const norcAuth = { acronym: 'NORC', siteCode: 123456 };
+
+    const createGeoRequest = (body) => httpMocks.createRequest({
+        method: 'POST',
+        headers: {
+            'x-forwarded-for': 'unit-test',
+            authorization: 'Bearer fake-token',
+        },
+        connection: {},
+        body,
+    });
+
+    const createResponse = () => httpMocks.createResponse();
+
+    it('returns 200 and stores valid rows', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'participant-doc',
+            data: { Connect_ID: 1234567890 },
+        });
+        const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1234567890,
+                '826796611': '123 Main St',
+                '202200799': 'IL',
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res._getJSONData().code).toBe(200);
+        expect(res._getJSONData().results[0]).toHaveProperty('Success');
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledWith([{
+            connectId: 1234567890,
+            fields: {
+                '826796611': '123 Main St',
+                '202200799': 'IL',
+            },
+        }]);
+    });
+
+    it('returns 206 with mixed valid and invalid rows (partial acceptance)', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID')
+            .mockResolvedValueOnce({
+                id: 'doc-1',
+                data: { Connect_ID: 1111111111 },
+            })
+            .mockResolvedValueOnce(null);
+        const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
+
+        const req = createGeoRequest({
+            data: [
+                { Connect_ID: 1111111111, '202200799': 'NY' },
+                { Connect_ID: 9999999999 },
+            ],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const results = res._getJSONData().results;
+        expect(results[0]).toHaveProperty('Success');
+        expect(results[1]).toHaveProperty('Invalid Request');
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy.mock.calls[0][0]).toHaveLength(1);
+    });
+
+    it('rejects rows with missing Connect_ID', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+
+        const req = createGeoRequest({
+            data: [{ '202200799': 'CA' }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const result = res._getJSONData().results[0];
+        expect(result['Invalid Request'].Connect_ID).toBe('UNDEFINED');
+    });
+
+    it('rejects rows for destroyed participants', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-destroyed',
+            data: {
+                Connect_ID: 5555555555,
+                [fieldMapping.participantMap.dataHasBeenDestroyed]: fieldMapping.yes,
+            },
+        });
+
+        const req = createGeoRequest({
+            data: [{ Connect_ID: 5555555555, '202200799': 'TX' }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        expect(res._getJSONData().results[0]['Invalid Request'].Errors).toBe('Data Destroyed');
+    });
+
+    it('rejects rows with validation errors (wrong type)', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '202200799': 12345,
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
+        expect(errors[0]).toContain('must be a string');
+    });
+
+    it('rejects rows with validation errors (exceeds maxLength)', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '202200799': 'ABC',
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
+        expect(errors[0]).toContain('at most 2 characters');
+    });
+
+    it('rejects rows with unknown concept IDs', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '999999999': 'unknown field',
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
+        expect(errors[0]).toContain('No validation rule exists');
+    });
+
+    it('skips blank fields without error and stores non-blank fields', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+        const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '826796611': '456 Oak Ave',
+                '202200799': '',
+                '565540989': null,
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(writeSpy).toHaveBeenCalledWith([{
+            connectId: 1111111111,
+            fields: { '826796611': '456 Oak Ave' },
+        }]);
+    });
+
+    it('returns 500 if Firestore write fails', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+        vi.spyOn(firestore, 'writeGeocodedAddresses').mockRejectedValue(new Error('Firestore unavailable'));
+
+        const req = createGeoRequest({
+            data: [{ Connect_ID: 1111111111, '202200799': 'CA' }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(500);
     });
 });

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -265,6 +265,9 @@ describe('test changed functions', () => {
 describe('geocodedAddresses', () => {
     const norcAuth = { acronym: 'NORC', siteCode: 123456 };
 
+    // Valid values for the two required fields (758212868 and 625954624).
+    const requiredFields = { '758212868': 12345, '625954624': 'geocode-id-abc123' };
+
     const createGeoRequest = (body) => httpMocks.createRequest({
         method: 'POST',
         headers: {
@@ -295,6 +298,7 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1234567890,
+                ...requiredFields,
                 '826796611': '123 Main St',
                 '202200799': 'IL',
             }],
@@ -310,6 +314,7 @@ describe('geocodedAddresses', () => {
         expect(writeSpy).toHaveBeenCalledWith([{
             connectId: 1234567890,
             fields: {
+                ...requiredFields,
                 '826796611': '123 Main St',
                 '202200799': 'IL',
             },
@@ -327,7 +332,7 @@ describe('geocodedAddresses', () => {
 
         const req = createGeoRequest({
             data: [
-                { Connect_ID: 1111111111, '202200799': 'NY' },
+                { Connect_ID: 1111111111, ...requiredFields, '202200799': 'NY' },
                 { Connect_ID: 9999999999 },
             ],
         });
@@ -390,6 +395,7 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1111111111,
+                ...requiredFields,
                 '202200799': 12345,
             }],
         });
@@ -412,6 +418,7 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1111111111,
+                ...requiredFields,
                 '202200799': 'ABC',
             }],
         });
@@ -434,7 +441,8 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1111111111,
-                '758212868': 123456, // rule: number, maxLength 5 -> 6 digits is too long
+                '758212868': 1234567, // rule: number, maxLength 6 -> 7 digits is too long
+                '625954624': 'geocode-id-abc123',
             }],
         });
         const res = createResponse();
@@ -443,7 +451,7 @@ describe('geocodedAddresses', () => {
 
         expect(res.statusCode).toBe(206);
         const errors = res._getJSONData().results[0]['Invalid Request'].Errors;
-        expect(errors[0]).toContain('less than 5 digits');
+        expect(errors[0]).toContain('less than 6 digits');
     });
 
     it('rejects rows with unknown concept IDs', async () => {
@@ -456,6 +464,7 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1111111111,
+                ...requiredFields,
                 '999999999': 'unknown field',
             }],
         });
@@ -479,6 +488,7 @@ describe('geocodedAddresses', () => {
         const req = createGeoRequest({
             data: [{
                 Connect_ID: 1111111111,
+                ...requiredFields,
                 '826796611': '456 Oak Ave',
                 '202200799': '',
                 '565540989': null,
@@ -491,7 +501,7 @@ describe('geocodedAddresses', () => {
         expect(res.statusCode).toBe(200);
         expect(writeSpy).toHaveBeenCalledWith([{
             connectId: 1111111111,
-            fields: { '826796611': '456 Oak Ave' },
+            fields: { ...requiredFields, '826796611': '456 Oak Ave' },
         }]);
     });
 
@@ -504,7 +514,7 @@ describe('geocodedAddresses', () => {
         vi.spyOn(firestore, 'writeGeocodedAddresses').mockRejectedValue(new Error('Firestore unavailable'));
 
         const req = createGeoRequest({
-            data: [{ Connect_ID: 1111111111, '202200799': 'CA' }],
+            data: [{ Connect_ID: 1111111111, ...requiredFields, '202200799': 'CA' }],
         });
         const res = createResponse();
 
@@ -535,6 +545,30 @@ describe('geocodedAddresses', () => {
         expect(res._getJSONData().results[0]['Invalid Request'].Errors).toBe('No non-blank fields provided.');
     });
 
+    it('rejects rows missing required fields', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockResolvedValue(participantMapOf({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        }));
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '202200799': 'CA',
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const error = res._getJSONData().results[0]['Invalid Request'].Errors;
+        expect(error).toContain('Missing required field(s)');
+        expect(error).toContain('758212868');
+        expect(error).toContain('625954624');
+    });
+
     it('returns 500 if the participant batch lookup fails', async () => {
         vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
         vi.spyOn(firestore, 'getParticipantsDataByConnectIds').mockRejectedValue(
@@ -560,7 +594,7 @@ describe('geocodedAddresses', () => {
         const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
 
         const req = createGeoRequest({
-            data: [{ Connect_ID: '1111111111', '202200799': 'CA' }],
+            data: [{ Connect_ID: '1111111111', ...requiredFields, '202200799': 'CA' }],
         });
         const res = createResponse();
 

--- a/test/unit/sites.test.js
+++ b/test/unit/sites.test.js
@@ -483,4 +483,64 @@ describe('geocodedAddresses', () => {
 
         expect(res.statusCode).toBe(500);
     });
+
+    it('rejects rows where all fields are blank', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+
+        const req = createGeoRequest({
+            data: [{
+                Connect_ID: 1111111111,
+                '826796611': '',
+                '202200799': null,
+            }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        expect(res._getJSONData().results[0]['Invalid Request'].Errors).toBe('No non-blank fields provided.');
+    });
+
+    it('handles getParticipantDataByConnectID throwing (e.g. duplicate Connect_ID)', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockRejectedValue(
+            new Error('Multiple participants found with connectId 1111111111')
+        );
+
+        const req = createGeoRequest({
+            data: [{ Connect_ID: 1111111111, '202200799': 'CA' }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(206);
+        const result = res._getJSONData().results[0];
+        expect(result['Server Error'].Errors).toContain('Multiple participants found');
+    });
+
+    it('normalizes Connect_ID to number for consistent hashing', async () => {
+        vi.spyOn(shared, 'APIAuthorization').mockResolvedValue(norcAuth);
+        vi.spyOn(firestore, 'getParticipantDataByConnectID').mockResolvedValue({
+            id: 'doc-1',
+            data: { Connect_ID: 1111111111 },
+        });
+        const writeSpy = vi.spyOn(firestore, 'writeGeocodedAddresses').mockResolvedValue();
+
+        const req = createGeoRequest({
+            data: [{ Connect_ID: '1111111111', '202200799': 'CA' }],
+        });
+        const res = createResponse();
+
+        await geocodedAddresses(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(writeSpy.mock.calls[0][0][0].connectId).toBe(1111111111);
+        expect(typeof writeSpy.mock.calls[0][0][0].connectId).toBe('number');
+    });
 });

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -7105,6 +7105,60 @@ const getEmailSuppressions = async (emailArray, mailStream) => {
   return suppressedSet;
 };
 
+/**
+ * Generate a deterministic document ID for a geocoded address row.
+ * The hash is derived from Connect_ID + all non-blank field values (sorted by key)
+ * so identical payloads on retry produce the same doc ID (idempotent upsert).
+ * @param {number|string} connectId
+ * @param {object} fields - The address fields (excluding Connect_ID), already stripped of blanks.
+ * @returns {string} A hex hash string suitable as a Firestore document ID.
+ */
+const generateGeocodedAddressDocId = (connectId, fields) => {
+    const crypto = require('crypto');
+    const sortedEntries = Object.entries(fields).sort(([a], [b]) => a.localeCompare(b));
+    const payload = `${connectId}:${JSON.stringify(sortedEntries)}`;
+    return crypto.createHash('sha256').update(payload).digest('hex');
+};
+
+/**
+ * Write a batch of validated geocoded address rows to the geocodedAddresses collection.
+ * Uses deterministic doc IDs so retries are idempotent (set with merge).
+ * Respects the Firestore batch limit of 500 operations per commit.
+ * @param {Array<{connectId: number|string, fields: object}>} rows - Array of validated row objects.
+ * @returns {Promise<void>}
+ */
+const writeGeocodedAddresses = async (rows) => {
+    const batchLimit = 500;
+    let batch = db.batch();
+    let counter = 0;
+    const batchPromises = [];
+
+    for (const { connectId, fields } of rows) {
+        const docId = generateGeocodedAddressDocId(connectId, fields);
+        const docRef = db.collection('geocodedAddresses').doc(docId);
+        const docData = {
+            Connect_ID: +connectId,
+            ...fields,
+            d_generated_hash: docId,
+            d_received_timestamp: new Date().toISOString(),
+        };
+        batch.set(docRef, docData, { merge: true });
+        counter++;
+
+        if (counter >= batchLimit) {
+            batchPromises.push(batch.commit());
+            batch = db.batch();
+            counter = 0;
+        }
+    }
+
+    if (counter > 0) {
+        batchPromises.push(batch.commit());
+    }
+
+    await Promise.all(batchPromises);
+};
+
 module.exports = {
     db,
     storage,
@@ -7283,4 +7337,6 @@ module.exports = {
     getMySamples,
     getAllMySamples,
     updateMySamples,
+    generateGeocodedAddressDocId,
+    writeGeocodedAddresses,
 };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -7113,7 +7113,11 @@ const getEmailSuppressions = async (emailArray, mailStream) => {
  * @returns {Promise<Map<number, {id: string, data: object}>>} Map keyed by Connect_ID (number).
  */
 const getParticipantsDataByConnectIds = async (connectIds) => {
-    const uniqueIds = [...new Set(connectIds.map(id => +id))];
+    const uniqueIds = [...new Set(connectIds
+        .map((id) => Number(id))
+        .filter((id) => Number.isFinite(id)))];
+    if (uniqueIds.length === 0) return new Map();
+
     const chunkSize = 30;
     const queries = [];
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -7139,8 +7139,7 @@ const writeGeocodedAddresses = async (rows) => {
         const docData = {
             Connect_ID: +connectId,
             ...fields,
-            d_generated_hash: docId,
-            d_received_timestamp: new Date().toISOString(),
+            received_timestamp: new Date().toISOString(),
         };
         batch.set(docRef, docData, { merge: true });
         counter++;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -7106,9 +7106,40 @@ const getEmailSuppressions = async (emailArray, mailStream) => {
 };
 
 /**
+ * Fetch participant records for a batch of Connect_IDs up front, instead of a
+ * sequential lookup per row. Firestore caps 'in' queries at 30 values, so the
+ * IDs are de-duplicated and chunked, and the chunk queries run in parallel.
+ * @param {Array<number|string>} connectIds
+ * @returns {Promise<Map<number, {id: string, data: object}>>} Map keyed by Connect_ID (number).
+ */
+const getParticipantsDataByConnectIds = async (connectIds) => {
+    const uniqueIds = [...new Set(connectIds.map(id => +id))];
+    const chunkSize = 30;
+    const queries = [];
+
+    for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+        const chunk = uniqueIds.slice(i, i + chunkSize);
+        queries.push(db.collection('participants').where('Connect_ID', 'in', chunk).get());
+    }
+
+    const snapshots = await Promise.all(queries);
+    const participantMap = new Map();
+    for (const snapshot of snapshots) {
+        snapshot.forEach(doc => {
+            const data = doc.data();
+            participantMap.set(data.Connect_ID, { id: doc.id, data });
+        });
+    }
+
+    return participantMap;
+};
+
+/**
  * Generate a deterministic document ID for a geocoded address row.
  * The hash is derived from Connect_ID + all non-blank field values (sorted by key)
- * so identical payloads on retry produce the same doc ID (idempotent upsert).
+ * so the same address for a participant always maps to the same doc, preventing
+ * duplicate documents for an identical address (participants may still have
+ * multiple distinct address documents in this collection).
  * @param {number|string} connectId
  * @param {object} fields - The address fields (excluding Connect_ID), already stripped of blanks.
  * @returns {string} A hex hash string suitable as a Firestore document ID.
@@ -7336,6 +7367,7 @@ module.exports = {
     getMySamples,
     getAllMySamples,
     updateMySamples,
+    getParticipantsDataByConnectIds,
     generateGeocodedAddressDocId,
     writeGeocodedAddresses,
 };

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -821,10 +821,15 @@ const geocodedAddresses = async (req, res) => {
     // Fetch every participant record up front in batched queries rather than a
     // sequential lookup per row.
     const connectIdsToFetch = dataArray
-        .map(dataObj => dataObj.Connect_ID)
-        .filter(id => id !== undefined && id !== null && id !== '')
-        .map(id => +id);
-
+        .map((dataObj) => {
+            const raw = dataObj.Connect_ID;
+            if (raw === undefined || raw === null) return null;
+            const trimmed = typeof raw === 'string' ? raw.trim() : raw;
+            if (trimmed === '') return null;
+            const num = Number(trimmed);
+            return Number.isFinite(num) ? num : null;
+        })
+        .filter((id) => id !== null);
     let participantMap;
     try {
         participantMap = await getParticipantsDataByConnectIds(connectIdsToFetch);

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -789,6 +789,9 @@ const geocodedAddresses = async (req, res) => {
         return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
     }
 
+    // TODO: Remove this block in October 2026 when clients are ready to test.
+    return res.status(503).json(getResponseJSON('geocodedAddresses endpoint is not yet available.', 503));
+
     const { APIAuthorization } = require('./shared');
     const authorized = await APIAuthorization(req);
     if (authorized instanceof Error) {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -862,9 +862,17 @@ const geocodedAddresses = async (req, res) => {
             continue;
         }
 
-        const connectId = dataObj.Connect_ID;
+        const connectId = +dataObj.Connect_ID;
 
-        const record = await getParticipantDataByConnectID(connectId);
+        let record;
+        try {
+            record = await getParticipantDataByConnectID(connectId);
+        } catch (e) {
+            console.error(`Error looking up participant with Connect_ID ${connectId}: ${e}`);
+            batchError = true;
+            responseArray.push({'Server Error': {'Connect_ID': connectId, 'Errors': `Please retry this row. Error: ${e.message}`}});
+            continue;
+        }
 
         if (!record) {
             batchError = true;
@@ -910,6 +918,12 @@ const geocodedAddresses = async (req, res) => {
         if (errors.length !== 0) {
             batchError = true;
             responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': errors}});
+            continue;
+        }
+
+        if (Object.keys(storedFields).length === 0) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': 'No non-blank fields provided.'}});
             continue;
         }
 

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -885,6 +885,16 @@ const geocodedAddresses = async (req, res) => {
             continue;
         }
 
+        // Enforce required fields from geocodedAddresses.json.
+        const missingRequired = Object.entries(geocodedAddressRules)
+            .filter(([key, rule]) => rule.required && !(key in storedFields))
+            .map(([key]) => key);
+        if (missingRequired.length > 0) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': `Missing required field(s): ${missingRequired.join(', ')}.`}});
+            continue;
+        }
+
         // Validate with the shared rules engine against geocodedAddresses.json.
         const errors = flatValidationHandler(storedFields, {}, geocodedAddressRules, validateUpdateParticipantData);
         if (errors.length !== 0) {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -585,6 +585,9 @@ const validateUpdateParticipantData = (value, existingValue, path, rule) => {
             if (typeof value !== 'number') {
                 return `Data mismatch: ${path} must be a number.`;
             }
+            if (rule.maxLength && value.toString().length > rule.maxLength) {
+                return `Data mismatch: ${path} must be less than ${rule.maxLength} digits. It is currently ${value.toString().length} digits.`;
+            }
             if (rule.values && !rule.values.includes(value)) {
                 return `Data mismatch: ${path} must be one of the following values: ${rule.values.join(', ')}.`;
             }
@@ -776,49 +779,6 @@ const getBigQueryData = async (req, res) => {
     return res.status(error ? 500 : 200).json(error ? getResponseJSON(error, 500) : {code: 200, results: responseArray});
 }
 
-/**
- * Validate a single field value for the geocodedAddresses endpoint.
- * @param {string|number} value - The non-blank value to validate.
- * @param {string} path - The concept ID key (e.g. '758212868').
- * @param {object} rule - The validation rule from geocodedAddresses.json.
- * @returns {string|null} An error message string on failure, or null on success.
- */
-const validateGeocodedAddressData = (value, path, rule) => {
-    switch (rule.dataType) {
-        case 'string':
-            if (typeof value !== 'string') {
-                return `Data mismatch: ${path} must be a string.`;
-            }
-            if (rule.maxLength && value.length > rule.maxLength) {
-                return `Data mismatch: ${path} must be at most ${rule.maxLength} characters. It is currently ${value.length} characters.`;
-            }
-            if (rule.values && !rule.values.includes(value)) {
-                return `Data mismatch: ${path} must be one of the following values: ${rule.values.join(', ')}.`;
-            }
-            break;
-
-        case 'number':
-            if (typeof value !== 'number') {
-                return `Data mismatch: ${path} must be a number.`;
-            }
-            if (rule.maxLength && value.toString().length > rule.maxLength) {
-                return `Data mismatch: ${path} must be at most ${rule.maxLength} digits. It is currently ${value.toString().length} digits.`;
-            }
-            if (rule.values && !rule.values.includes(value)) {
-                return `Data mismatch: ${path} must be one of the following values: ${rule.values.join(', ')}.`;
-            }
-            break;
-
-        default:
-            if (typeof value !== rule.dataType) {
-                return `Data mismatch: ${path} must be a ${rule.dataType}.`;
-            }
-            break;
-    }
-
-    return null;
-};
-
 const geocodedAddresses = async (req, res) => {
     logIPAddress(req);
     setHeaders(res);
@@ -839,6 +799,9 @@ const geocodedAddresses = async (req, res) => {
         return res.status(401).json(getResponseJSON('Authorization failed!', 401));
     }
 
+    // NORC is the geocoding vendor for the whole study and is intentionally
+    // authorized to submit geocoded addresses for participants at any site,
+    // so the participant lookup below is deliberately not scoped by site code.
     if (authorized.acronym !== 'NORC') {
         return res.status(403).json(getResponseJSON('You are not authorized!', 403));
     }
@@ -848,12 +811,29 @@ const geocodedAddresses = async (req, res) => {
     if (req.body.data.length === 0) return res.status(400).json(getResponseJSON('Bad request. Data array does not have any elements.', 400));
     if (req.body.data.length > 500) return res.status(400).json(getResponseJSON('Bad request. Data contains more than acceptable limit of 500 records.', 400));
 
-    const { getParticipantDataByConnectID, writeGeocodedAddresses } = require('./firestore');
+    const { getParticipantsDataByConnectIds, writeGeocodedAddresses } = require('./firestore');
 
     const dataArray = req.body.data;
-    let responseArray = [];
+    const responseArray = [];
     let batchError = false;
     const validRows = [];
+
+    // Fetch every participant record up front in batched queries rather than a
+    // sequential lookup per row.
+    const connectIdsToFetch = dataArray
+        .map(dataObj => dataObj.Connect_ID)
+        .filter(id => id !== undefined && id !== null && id !== '')
+        .map(id => +id);
+
+    let participantMap;
+    try {
+        participantMap = await getParticipantsDataByConnectIds(connectIdsToFetch);
+    } catch (e) {
+        console.error(`Error looking up participants for geocoded addresses: ${e}`);
+        return res.status(500).json(getResponseJSON('Internal server error while looking up participants.', 500));
+    }
+
+    const dataHasBeenDestroyed = fieldMapping.participantMap.dataHasBeenDestroyed.toString();
 
     for (let dataObj of dataArray) {
         if (dataObj.Connect_ID === undefined || dataObj.Connect_ID === null || dataObj.Connect_ID === '') {
@@ -863,16 +843,7 @@ const geocodedAddresses = async (req, res) => {
         }
 
         const connectId = +dataObj.Connect_ID;
-
-        let record;
-        try {
-            record = await getParticipantDataByConnectID(connectId);
-        } catch (e) {
-            console.error(`Error looking up participant with Connect_ID ${connectId}: ${e}`);
-            batchError = true;
-            responseArray.push({'Server Error': {'Connect_ID': connectId, 'Errors': `Please retry this row. Error: ${e.message}`}});
-            continue;
-        }
+        const record = participantMap.get(connectId);
 
         if (!record) {
             batchError = true;
@@ -880,50 +851,33 @@ const geocodedAddresses = async (req, res) => {
             continue;
         }
 
-        const docData = record.data;
-
         // Reject if participant data has been destroyed.
-        const dataHasBeenDestroyed = fieldMapping.participantMap.dataHasBeenDestroyed.toString();
-        if (docData[dataHasBeenDestroyed] === fieldMapping.yes) {
+        if (record.data[dataHasBeenDestroyed] === fieldMapping.yes) {
             batchError = true;
             responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': 'Data Destroyed'}});
             continue;
         }
 
-        // Validate each field against geocodedAddresses rules.
-        // Blank/null/undefined values are skipped (not validated, not stored).
-        const errors = [];
+        // Collect the non-blank fields to store. Blank/null/undefined values are
+        // skipped (neither validated nor stored).
         const storedFields = {};
         for (const [key, value] of Object.entries(dataObj)) {
             if (key === 'Connect_ID') continue;
-
-            if (value === undefined || value === null || value === '') {
-                continue;
-            }
-
-            const rule = geocodedAddressRules[key];
-            if (!rule) {
-                errors.push(`Error: No validation rule exists for "${key}".`);
-                continue;
-            }
-
-            const error = validateGeocodedAddressData(value, key, rule);
-            if (error) {
-                errors.push(error);
-            } else {
-                storedFields[key] = value;
-            }
-        }
-
-        if (errors.length !== 0) {
-            batchError = true;
-            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': errors}});
-            continue;
+            if (value === undefined || value === null || value === '') continue;
+            storedFields[key] = value;
         }
 
         if (Object.keys(storedFields).length === 0) {
             batchError = true;
             responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': 'No non-blank fields provided.'}});
+            continue;
+        }
+
+        // Validate with the shared rules engine against geocodedAddresses.json.
+        const errors = flatValidationHandler(storedFields, {}, geocodedAddressRules, validateUpdateParticipantData);
+        if (errors.length !== 0) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': errors}});
             continue;
         }
 
@@ -951,6 +905,5 @@ module.exports = {
     updateParticipantData,
     updateRecruit,
     updateUserAuthentication,
-    participantDataCorrection,
-    validateGeocodedAddressData
+    participantDataCorrection
 }

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -846,11 +846,14 @@ const geocodedAddresses = async (req, res) => {
     if (req.body.data === undefined) return res.status(400).json(getResponseJSON('Bad request. Data is not defined in request body.', 400));
     if (!Array.isArray(req.body.data)) return res.status(400).json(getResponseJSON('Bad request. Data must be an array.', 400));
     if (req.body.data.length === 0) return res.status(400).json(getResponseJSON('Bad request. Data array does not have any elements.', 400));
-    if (req.body.data.length > 1000) return res.status(400).json(getResponseJSON('Bad request. Data contains more than acceptable limit of 1000 records.', 400));
+    if (req.body.data.length > 500) return res.status(400).json(getResponseJSON('Bad request. Data contains more than acceptable limit of 500 records.', 400));
+
+    const { getParticipantDataByConnectID, writeGeocodedAddresses } = require('./firestore');
 
     const dataArray = req.body.data;
     let responseArray = [];
     let batchError = false;
+    const validRows = [];
 
     for (let dataObj of dataArray) {
         if (dataObj.Connect_ID === undefined || dataObj.Connect_ID === null || dataObj.Connect_ID === '') {
@@ -861,7 +864,6 @@ const geocodedAddresses = async (req, res) => {
 
         const connectId = dataObj.Connect_ID;
 
-        const { getParticipantDataByConnectID } = require('./firestore');
         const record = await getParticipantDataByConnectID(connectId);
 
         if (!record) {
@@ -883,6 +885,7 @@ const geocodedAddresses = async (req, res) => {
         // Validate each field against geocodedAddresses rules.
         // Blank/null/undefined values are skipped (not validated, not stored).
         const errors = [];
+        const storedFields = {};
         for (const [key, value] of Object.entries(dataObj)) {
             if (key === 'Connect_ID') continue;
 
@@ -897,7 +900,11 @@ const geocodedAddresses = async (req, res) => {
             }
 
             const error = validateGeocodedAddressData(value, key, rule);
-            if (error) errors.push(error);
+            if (error) {
+                errors.push(error);
+            } else {
+                storedFields[key] = value;
+            }
         }
 
         if (errors.length !== 0) {
@@ -906,8 +913,18 @@ const geocodedAddresses = async (req, res) => {
             continue;
         }
 
-        // TODO: Storage logic will be implemented in a future step.
+        validRows.push({ connectId, fields: storedFields });
         responseArray.push({'Success': {'Connect_ID': connectId, 'Errors': 'None'}});
+    }
+
+    // Write all valid rows to Firestore in batched commits.
+    if (validRows.length > 0) {
+        try {
+            await writeGeocodedAddresses(validRows);
+        } catch (e) {
+            console.error(`Error writing geocoded addresses to Firestore: ${e}`);
+            return res.status(500).json(getResponseJSON('Internal server error while storing geocoded address data.', 500));
+        }
     }
 
     return res.status(batchError ? 206 : 200).json({code: batchError ? 206 : 200, results: responseArray});

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -841,13 +841,20 @@ const geocodedAddresses = async (req, res) => {
     const dataHasBeenDestroyed = fieldMapping.participantMap.dataHasBeenDestroyed.toString();
 
     for (let dataObj of dataArray) {
-        if (dataObj.Connect_ID === undefined || dataObj.Connect_ID === null || dataObj.Connect_ID === '') {
+        const rawConnectId = dataObj.Connect_ID;
+        if (rawConnectId === undefined || rawConnectId === null || rawConnectId === '') {
             batchError = true;
             responseArray.push({'Invalid Request': {'Connect_ID': 'UNDEFINED', 'Errors': 'Connect_ID not defined in data object.'}});
             continue;
         }
 
-        const connectId = +dataObj.Connect_ID;
+        const connectId = Number(typeof rawConnectId === 'string' ? rawConnectId.trim() : rawConnectId);
+        if (!Number.isFinite(connectId)) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': rawConnectId, 'Errors': 'Connect_ID must be a valid number.'}});
+            continue;
+        }
+
         const record = participantMap.get(connectId);
 
         if (!record) {

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -1,5 +1,6 @@
 const rules = require("../updateParticipantData.json");
 const submitRules = require("../submitParticipantData.json");
+const geocodedAddressRules = require("../geocodedAddresses.json");
 const { getResponseJSON, setHeaders, logIPAddress, validPhoneFormat, validEmailFormat, refusalWithdrawalConcepts } = require('./shared');
 const { validateIso8601Timestamp } = require('./validation');
 const fieldMapping = require('./fieldToConceptIdMapping');
@@ -775,12 +776,150 @@ const getBigQueryData = async (req, res) => {
     return res.status(error ? 500 : 200).json(error ? getResponseJSON(error, 500) : {code: 200, results: responseArray});
 }
 
+/**
+ * Validate a single field value for the geocodedAddresses endpoint.
+ * @param {string|number} value - The non-blank value to validate.
+ * @param {string} path - The concept ID key (e.g. '758212868').
+ * @param {object} rule - The validation rule from geocodedAddresses.json.
+ * @returns {string|null} An error message string on failure, or null on success.
+ */
+const validateGeocodedAddressData = (value, path, rule) => {
+    switch (rule.dataType) {
+        case 'string':
+            if (typeof value !== 'string') {
+                return `Data mismatch: ${path} must be a string.`;
+            }
+            if (rule.maxLength && value.length > rule.maxLength) {
+                return `Data mismatch: ${path} must be at most ${rule.maxLength} characters. It is currently ${value.length} characters.`;
+            }
+            if (rule.values && !rule.values.includes(value)) {
+                return `Data mismatch: ${path} must be one of the following values: ${rule.values.join(', ')}.`;
+            }
+            break;
+
+        case 'number':
+            if (typeof value !== 'number') {
+                return `Data mismatch: ${path} must be a number.`;
+            }
+            if (rule.maxLength && value.toString().length > rule.maxLength) {
+                return `Data mismatch: ${path} must be at most ${rule.maxLength} digits. It is currently ${value.toString().length} digits.`;
+            }
+            if (rule.values && !rule.values.includes(value)) {
+                return `Data mismatch: ${path} must be one of the following values: ${rule.values.join(', ')}.`;
+            }
+            break;
+
+        default:
+            if (typeof value !== rule.dataType) {
+                return `Data mismatch: ${path} must be a ${rule.dataType}.`;
+            }
+            break;
+    }
+
+    return null;
+};
+
+const geocodedAddresses = async (req, res) => {
+    logIPAddress(req);
+    setHeaders(res);
+
+    if (req.method === 'OPTIONS') return res.status(200).json({code: 200});
+
+    if (req.method !== 'POST') {
+        return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+    }
+
+    const { APIAuthorization } = require('./shared');
+    const authorized = await APIAuthorization(req);
+    if (authorized instanceof Error) {
+        return res.status(500).json(getResponseJSON(authorized.message, 500));
+    }
+
+    if (!authorized) {
+        return res.status(401).json(getResponseJSON('Authorization failed!', 401));
+    }
+
+    if (authorized.acronym !== 'NORC') {
+        return res.status(403).json(getResponseJSON('You are not authorized!', 403));
+    }
+
+    if (req.body.data === undefined) return res.status(400).json(getResponseJSON('Bad request. Data is not defined in request body.', 400));
+    if (!Array.isArray(req.body.data)) return res.status(400).json(getResponseJSON('Bad request. Data must be an array.', 400));
+    if (req.body.data.length === 0) return res.status(400).json(getResponseJSON('Bad request. Data array does not have any elements.', 400));
+    if (req.body.data.length > 1000) return res.status(400).json(getResponseJSON('Bad request. Data contains more than acceptable limit of 1000 records.', 400));
+
+    const dataArray = req.body.data;
+    let responseArray = [];
+    let batchError = false;
+
+    for (let dataObj of dataArray) {
+        if (dataObj.Connect_ID === undefined || dataObj.Connect_ID === null || dataObj.Connect_ID === '') {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': 'UNDEFINED', 'Errors': 'Connect_ID not defined in data object.'}});
+            continue;
+        }
+
+        const connectId = dataObj.Connect_ID;
+
+        const { getParticipantDataByConnectID } = require('./firestore');
+        const record = await getParticipantDataByConnectID(connectId);
+
+        if (!record) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': 'Participant with this Connect_ID does not exist.'}});
+            continue;
+        }
+
+        const docData = record.data;
+
+        // Reject if participant data has been destroyed.
+        const dataHasBeenDestroyed = fieldMapping.participantMap.dataHasBeenDestroyed.toString();
+        if (docData[dataHasBeenDestroyed] === fieldMapping.yes) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': 'Data Destroyed'}});
+            continue;
+        }
+
+        // Validate each field against geocodedAddresses rules.
+        // Blank/null/undefined values are skipped (not validated, not stored).
+        const errors = [];
+        for (const [key, value] of Object.entries(dataObj)) {
+            if (key === 'Connect_ID') continue;
+
+            if (value === undefined || value === null || value === '') {
+                continue;
+            }
+
+            const rule = geocodedAddressRules[key];
+            if (!rule) {
+                errors.push(`Error: No validation rule exists for "${key}".`);
+                continue;
+            }
+
+            const error = validateGeocodedAddressData(value, key, rule);
+            if (error) errors.push(error);
+        }
+
+        if (errors.length !== 0) {
+            batchError = true;
+            responseArray.push({'Invalid Request': {'Connect_ID': connectId, 'Errors': errors}});
+            continue;
+        }
+
+        // TODO: Storage logic will be implemented in a future step.
+        responseArray.push({'Success': {'Connect_ID': connectId, 'Errors': 'None'}});
+    }
+
+    return res.status(batchError ? 206 : 200).json({code: batchError ? 206 : 200, results: responseArray});
+};
 
 module.exports = {
     getBigQueryData,
+    geocodedAddresses,
     submitParticipantsData,
     updateParticipantData,
     updateRecruit,
     updateUserAuthentication,
-    participantDataCorrection
+    participantDataCorrection,
+    validateGeocodedAddressData
 }


### PR DESCRIPTION
Issue Addressed: https://github.com/episphere/connect/issues/1621

This pull request introduces a new `geocodedAddresses` API endpoint for handling geocoded address data submissions.

---

**New API Endpoint and Logic:**
* Added a new `geocodedAddresses` function to `utils/sites` and registered it in `index.js`, exposing it as an API endpoint. This endpoint allows authorized sites (specifically NORC) to submit geocoded address data for participants, with strict validation and error handling. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L5-R5) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R29)

**Validation and Schema Support:**
* Introduced a `geocodedAddresses.json` file defining validation rules (data types, max lengths, allowed values) for each supported field/concept ID, enabling robust input validation for the endpoint.

**Testing Enhancements:**
* Added comprehensive unit tests in `test/unit/sites.test.js` for the new endpoint, covering authorization, validation errors, partial acceptance, Firestore failures, and normalization of input data.
* Updated `test/unit/apiEndpoints.test.js` to include the new endpoint in method guards, authorization checks, and error handling tests. [[1]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbL19-R19) [[2]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbR40) [[3]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbR97) [[4]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbR122) [[5]](diffhunk://#diff-932913a1558702cc560ad5ee70a371b90fd720b327508fe4a65d262d95317fcbR168-R220)
* Updated test imports and mocks to include the new function. [[1]](diffhunk://#diff-f4a23cbdd649e648fea8bbb45ff1014033d2897fca4310d5bb500cda1ce26db1R19) [[2]](diffhunk://#diff-f4a23cbdd649e648fea8bbb45ff1014033d2897fca4310d5bb500cda1ce26db1R34)

**Deployment Configuration:**
* Added a new Cloud Build YAML configuration (`config/yaml/geocodedAddresses.yaml`) for deploying the `geocodedAddresses` service to Google Cloud Run, including IAM policy binding for public invocation.