### PR TITLE
store incoming msg

### DIFF
--- a/test/unit/emailSuppression.test.js
+++ b/test/unit/emailSuppression.test.js
@@ -40,15 +40,6 @@ const sharedMock = {
 };
 require.cache[sharedPath].exports = sharedMock;
 
-// Mock bigquery.js to add phone-token lookup used by firestore.js
-const bigqueryPath = require.resolve("../../utils/bigquery");
-const origBigqueryExports = require.cache[bigqueryPath].exports;
-const bigqueryMock = {
-  ...origBigqueryExports,
-  getParticipantTokensByPhoneNumber: vi.fn().mockResolvedValue([]),
-};
-require.cache[bigqueryPath].exports = bigqueryMock;
-
 // Add getAll to the Firestore mock to support batch lookups
 firestoreMocks.mockFirestore.getAll = vi.fn().mockResolvedValue([]);
 const firestorePath = require.resolve("../../utils/firestore");
@@ -70,7 +61,6 @@ describe("Email Suppression System", () => {
 
   afterAll(() => {
     require.cache[sharedPath].exports = origSharedExports;
-    require.cache[bigqueryPath].exports = origBigqueryExports;
     delete require.cache[firestorePath];
     restoreModuleMocks();
   });

--- a/test/unit/notifications.test.js
+++ b/test/unit/notifications.test.js
@@ -36,6 +36,7 @@ const functionsAdminMock = {
 const bigqueryMock = {
   getParticipantsForNotificationsBQ: vi.fn().mockResolvedValue([]),
   countParticipantsForNotificationsBQ: vi.fn().mockResolvedValue(0),
+  getTokensAndPreferredLanguageByPhone: vi.fn().mockResolvedValue({ tokens: [], preferredLanguage: null }),
 };
 
 const twilioClientMock = {
@@ -128,7 +129,8 @@ const firestoreMock = {
   markNotificationBatchFailed: vi.fn().mockResolvedValue(0),
   storeNotification: vi.fn().mockResolvedValue(undefined),
   checkIsNotificationSent: vi.fn(),
-  updateSmsPermission: vi.fn(),
+  updateSmsPermission: vi.fn().mockResolvedValue(0),
+  storeIncomingSmsData: vi.fn().mockResolvedValue(undefined),
   getAppSettings: vi.fn().mockResolvedValue({}),
   // Suppression functions mocked here so notifications.js can import them
   addEmailSuppression: vi.fn().mockResolvedValue(undefined),
@@ -152,6 +154,8 @@ const origSgMailExports = require.cache[sgMailPath].exports;
 const origFunctionsAdminExports = require.cache[functionsAdminPath].exports;
 const origSecretManagerExports = require.cache[secretManagerPath].exports;
 const origTwilioExports = require.cache[twilioPath].exports;
+twilioMock.validateRequest = vi.fn().mockReturnValue(true);
+twilioMock.twiml = origTwilioExports.twiml;
 
 const { SmsBatchSender } = require("../../utils/notifications");
 
@@ -242,12 +246,16 @@ describe("Notifications Unit Tests", () => {
     sgMailMock.send.mockReset().mockResolvedValue([{ statusCode: 202, body: {} }]);
     bigqueryMock.getParticipantsForNotificationsBQ.mockReset().mockResolvedValue([]);
     bigqueryMock.countParticipantsForNotificationsBQ.mockReset().mockResolvedValue(0);
+    bigqueryMock.getTokensAndPreferredLanguageByPhone.mockReset().mockResolvedValue({ tokens: [], preferredLanguage: null });
+    firestoreMock.updateSmsPermission.mockReset().mockResolvedValue(0);
+    firestoreMock.storeIncomingSmsData.mockReset().mockResolvedValue(undefined);
     taskQueueMock.enqueue.mockReset().mockResolvedValue(undefined);
     taskQueueSelectorMock.mockReset().mockImplementation(() => taskQueueMock);
     functionsAdminMock.getFunctions.mockReset().mockImplementation(() => ({
       taskQueue: taskQueueSelectorMock,
     }));
     twilioMock.mockClear();
+    twilioMock.validateRequest.mockReset().mockReturnValue(true);
     twilioClientMock.messages.create.mockReset().mockResolvedValue({ sid: "SM_mock_sid" });
 
     // Install mocks into require.cache
@@ -2943,6 +2951,136 @@ describe("Notifications Unit Tests", () => {
       expect(firestoreMock.markNotificationBatchAccepted).toHaveBeenCalledTimes(1);
       expect(firestoreMock.markNotificationBatchFailed).not.toHaveBeenCalled();
       expect(firestoreMock.markBulkNotificationBatchComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("handleIncomingSms", () => {
+    const createIncomingSmsRequest = (bodyOverrides = {}) => ({
+      body: {
+        MessageSid: "SM_incoming_mock",
+        From: "+16145550100",
+        To: "+13015550200",
+        Body: "Yes",
+        SmsStatus: "received",
+        ...bodyOverrides,
+      },
+      headers: { "x-twilio-signature": "mock-signature" },
+      get: vi.fn().mockReturnValue("example.com"),
+      originalUrl: "/webhook?api=twilio-incoming-sms",
+    });
+
+    const createIncomingSmsResponseMock = () => ({
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      sendStatus: vi.fn().mockReturnThis(),
+      type: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    });
+
+    it("should store the SMS and grant permission for matched tokens on START", async () => {
+      bigqueryMock.getTokensAndPreferredLanguageByPhone.mockResolvedValue({
+        tokens: ["tokenA", "tokenB"],
+        preferredLanguage: null,
+      });
+      const req = createIncomingSmsRequest({ OptOutType: "START", Body: "START" });
+      const res = createIncomingSmsResponseMock();
+
+      await notificationsModule.handleIncomingSms(req, res);
+
+      expect(firestoreMock.storeIncomingSmsData).toHaveBeenCalledWith(req.body);
+      expect(bigqueryMock.getTokensAndPreferredLanguageByPhone).toHaveBeenCalledWith("+16145550100");
+      expect(firestoreMock.updateSmsPermission).toHaveBeenCalledWith(["tokenA", "tokenB"], true);
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+      expect(res.send).not.toHaveBeenCalled();
+    });
+
+    it("should revoke permission for matched tokens on STOP", async () => {
+      bigqueryMock.getTokensAndPreferredLanguageByPhone.mockResolvedValue({
+        tokens: ["tokenA"],
+        preferredLanguage: conceptIds.english,
+      });
+      const req = createIncomingSmsRequest({ OptOutType: "STOP", Body: "STOP" });
+      const res = createIncomingSmsResponseMock();
+
+      await notificationsModule.handleIncomingSms(req, res);
+
+      expect(firestoreMock.updateSmsPermission).toHaveBeenCalledWith(["tokenA"], false);
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+    });
+
+    it("should reply in English to a regular message without a Spanish preference", async () => {
+      bigqueryMock.getTokensAndPreferredLanguageByPhone.mockResolvedValue({
+        tokens: ["tokenA"],
+        preferredLanguage: conceptIds.english,
+      });
+      const req = createIncomingSmsRequest();
+      const res = createIncomingSmsResponseMock();
+
+      await notificationsModule.handleIncomingSms(req, res);
+
+      expect(firestoreMock.updateSmsPermission).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.type).toHaveBeenCalledWith("text/xml");
+      expect(res.send).toHaveBeenCalledWith(expect.stringContaining("For help, visit MyConnect.cancer.gov/support."));
+    });
+
+    it("should reply in Spanish when the preferred language is Spanish", async () => {
+      bigqueryMock.getTokensAndPreferredLanguageByPhone.mockResolvedValue({
+        tokens: ["tokenA"],
+        preferredLanguage: conceptIds.spanish,
+      });
+      const req = createIncomingSmsRequest();
+      const res = createIncomingSmsResponseMock();
+
+      await notificationsModule.handleIncomingSms(req, res);
+
+      expect(res.send).toHaveBeenCalledWith(expect.stringContaining("Para ayuda, visite MyConnect.cancer.gov/support."));
+    });
+
+    it("should not update permission or reply on HELP", async () => {
+      const req = createIncomingSmsRequest({ OptOutType: "HELP", Body: "HELP" });
+      const res = createIncomingSmsResponseMock();
+
+      await notificationsModule.handleIncomingSms(req, res);
+
+      expect(firestoreMock.updateSmsPermission).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+    });
+
+    it("should return 403 when the Twilio signature is invalid", async () => {
+      twilioMock.validateRequest.mockReturnValue(false);
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const req = createIncomingSmsRequest();
+        const res = createIncomingSmsResponseMock();
+
+        await notificationsModule.handleIncomingSms(req, res);
+
+        expect(firestoreMock.storeIncomingSmsData).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(403);
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("should return 500 when updating SMS permission fails", async () => {
+      bigqueryMock.getTokensAndPreferredLanguageByPhone.mockResolvedValue({
+        tokens: ["tokenA"],
+        preferredLanguage: null,
+      });
+      firestoreMock.updateSmsPermission.mockRejectedValue(new Error("firestore down"));
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const req = createIncomingSmsRequest({ OptOutType: "STOP", Body: "STOP" });
+        const res = createIncomingSmsResponseMock();
+
+        await notificationsModule.handleIncomingSms(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 });

--- a/utils/bigquery.js
+++ b/utils/bigquery.js
@@ -452,27 +452,41 @@ const getCollectionStats = async (type, siteCode) => {
 }
 
 /**
- * 
+ * Finds tokens and the preferred language of participant(s) having the phone number.
+ * If matched participants have different preferred languages, the most common one is returned.
  * @param {string} fullNumber Phone number in the format +11234567890
- * @returns {Promise<string[]>} Array of tokens of participant(s) having the phone number
+ * @returns {Promise<{tokens: string[], preferredLanguage: number|null}>}
  */
-const getParticipantTokensByPhoneNumber = async (fullNumber) => {
+const getTokensAndPreferredLanguageByPhone = async (fullNumber) => {
   const tenDigitsNumber = fullNumber.slice(-10);
-  const query = `SELECT token FROM \`Connect.participants\` WHERE d_348474836 = @fullNumber OR d_388711124 = @tenDigitsNumber`;
+  const query = `SELECT token, d_${fieldMapping.preferredLanguage} AS preferredLanguage FROM \`Connect.participants\` WHERE d_348474836 = @fullNumber OR d_388711124 = @tenDigitsNumber`;
   const options = {
     query,
     location: "US",
     params: { fullNumber, tenDigitsNumber },
   };
-  
+
   let rows = [];
   try {
     [rows] = await bigquery.query(options);
   } catch (error) {
-    console.error("Error calling getParticipantTokensByPhoneNumber().", error);
+    console.error("Error calling getTokensAndPreferredLanguageByPhone().", error);
   }
-  
-  return rows.map(row => row.token);
+
+  if (rows.length === 0) {
+    return { tokens: [], preferredLanguage: null };
+  }
+
+  const tokens = [];
+  const languageCounts = {};
+  for (const row of rows) {
+    tokens.push(row.token);
+    languageCounts[row.preferredLanguage] = (languageCounts[row.preferredLanguage] ?? 0) + 1;
+  }
+  const topLanguage = parseInt(Object.entries(languageCounts).sort((a, b) => b[1] - a[1])[0][0], 10);
+  const preferredLanguage = Number.isFinite(topLanguage) ? topLanguage : null;
+
+  return { tokens, preferredLanguage };
 };
 
 /**
@@ -762,7 +776,7 @@ module.exports = {
     getParticipantsForRequestAKitBQ,
     getStatsFromBQ,
     getCollectionStats,
-    getParticipantTokensByPhoneNumber,
+    getTokensAndPreferredLanguageByPhone,
     validateFields,
     validateFilters,
     validateTableAccess,

--- a/utils/events.js
+++ b/utils/events.js
@@ -3,11 +3,12 @@ const {BigQuery} = require('@google-cloud/bigquery');
 const {Storage} = require('@google-cloud/storage');
 const { getResponseJSON } = require('./shared');
 
-const collectionNameArray = ['participants', 'biospecimen', 'boxes', 'module1_v1', 'module1_v2', 'module2_v1', 'module2_v2', 'module3_v1', 'module4_v1', 'bioSurvey_v1', 'menstrualSurvey_v1', 'clinicalBioSurvey_v1', 'covid19Survey_v1', 'kitAssembly', 'mouthwash_v1', 'cancerOccurrence', 'promis_v1', 'experience2024', 'birthdayCard', 'cancerScreeningHistorySurvey', 'dhqAnalysisResults', 'dhqDetailedAnalysis', 'dhqRawAnswers', 'preference2026'];
-const importCollectionNameArray = [...collectionNameArray, 'notifications'];
+const exportCollectionNameArray = ['participants', 'biospecimen', 'boxes', 'module1_v1', 'module1_v2', 'module2_v1', 'module2_v2', 'module3_v1', 'module4_v1', 'bioSurvey_v1', 'menstrualSurvey_v1', 'clinicalBioSurvey_v1', 'covid19Survey_v1', 'kitAssembly', 'mouthwash_v1', 'cancerOccurrence', 'promis_v1', 'experience2024', 'birthdayCard', 'cancerScreeningHistorySurvey', 'dhqAnalysisResults', 'dhqDetailedAnalysis', 'dhqRawAnswers', 'preference2026'];
+const exportOncePerDayCollectionNameArray = ['notifications', 'incomingSMS'];
+const importCollectionNameArray = [...exportCollectionNameArray, ...exportOncePerDayCollectionNameArray];
 
 const runFirestoreExport = async () => {
-  await exportCollectionsToBucket(collectionNameArray);
+  await exportCollectionsToBucket(exportCollectionNameArray);
 };
 
 const importToBigQuery = async (req, res) => {
@@ -30,7 +31,7 @@ const importToBigQuery = async (req, res) => {
 };
 
 const runExportNotificationsToBucket = async () => {
-  await exportCollectionsToBucket(["notifications"]);
+  await exportCollectionsToBucket(exportOncePerDayCollectionNameArray);
 };
 
 const firestoreExport = async (req, res) => {

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -460,4 +460,13 @@ module.exports = {
     dhq3HEIReportStatusExternal: 892697201, // [unread, viewed]
     dhq3HEIReportFirstViewedISOTime: 600958089,
     dhq3HEIReportFirstDeclinedISOTime: 404613256,
+
+    // Incoming SMS variables
+    smsSid: 137172032,
+    smsFrom: 756674860,
+    smsTo: 193005138,
+    smsContent: 115707416,
+    smsStatus: 432682375,
+    smsOptOutType: 689827049,
+    smsTimestamp: 700108581,
 };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -6334,11 +6334,11 @@ const disableSmsErrorCodes = ["21610", "30004", "30006"];
 /**
  * Processes Twilio SMS status webhook requests and updates the corresponding notification record in Firestore, with retry logic to handle potential delays in record availability. 
  * For specific error codes (21610, 30004, 30006), revokes SMS permission for the phone number.
- * @param {object} smsData - Twilio SMS webhook request body
- * @param {string} smsData.MessageSid - Unique identifier for the SMS message
- * @param {string} smsData.MessageStatus - Status of the message (e.g., "delivered", "failed", "undelivered")
- * @param {string} [smsData.ErrorCode] - Twilio error code if the message failed
- * @param {string} [smsData.ErrorMessage] - Twilio error message if the message failed
+ * @param {object} reqBody - Twilio SMS webhook request body
+ * @param {string} reqBody.MessageSid - Unique identifier for the SMS message
+ * @param {string} reqBody.MessageStatus - Status of the message (e.g., "delivered", "failed", "undelivered")
+ * @param {string} [reqBody.ErrorCode] - Twilio error code if the message failed
+ * @param {string} [reqBody.ErrorMessage] - Twilio error message if the message failed
  * @returns {Promise<void>}
  */
 const processTwilioEvent = async (reqBody) => {
@@ -6405,8 +6405,12 @@ const processTwilioEvent = async (reqBody) => {
  */
 const storeIncomingSmsData = async (smsData = {}) => {
   const { MessageSid, From, To, Body, SmsStatus, OptOutType } = smsData;
+  if (!MessageSid || !From) {
+    throw new Error('Missing required fields in incoming SMS data: MessageSid and From are required.');
+  }
+
   const smsRecord = {
-    [fieldMapping.smsSid]: MessageSid || "",
+    [fieldMapping.smsSid]: MessageSid,
     [fieldMapping.smsFrom]: From,
     [fieldMapping.smsTo]: To || "",
     [fieldMapping.smsContent]: Body || "",
@@ -6416,7 +6420,7 @@ const storeIncomingSmsData = async (smsData = {}) => {
   };
 
   try {
-    await db.collection("incomingSMS").add(smsRecord);
+    await db.collection("incomingSMS").doc(MessageSid).set(smsRecord);
   } catch (error) {
     throw new Error(`Error storing incoming SMS data for MessageSid ${MessageSid}.`, { cause: error });
   }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -8,7 +8,6 @@ const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit
 const fieldMapping = require('./fieldToConceptIdMapping');
 const { getCurrentPolicy, buildDataDestructionUpdate, validateDestroyedStub } = require('./dataDestructionPolicy');
 const { isIsoDate } = require('./validation');
-const {getParticipantTokensByPhoneNumber} = require('./bigquery');
 const { normalizeEmailAddress, getEmailSuppressionPolicyForSendGridEvent, buildEmailSuppressionDoc } = require('./emailSuppressionPolicy');
 const { isProviderSendStartedState } = require('./notificationState');
 
@@ -6335,11 +6334,11 @@ const disableSmsErrorCodes = ["21610", "30004", "30006"];
 /**
  * Processes Twilio SMS status webhook requests and updates the corresponding notification record in Firestore, with retry logic to handle potential delays in record availability. 
  * For specific error codes (21610, 30004, 30006), revokes SMS permission for the phone number.
- * @param {object} reqBody - Twilio SMS webhook request body
- * @param {string} reqBody.MessageSid - Unique identifier for the SMS message
- * @param {string} reqBody.MessageStatus - Status of the message (e.g., "delivered", "failed", "undelivered")
- * @param {string} [reqBody.ErrorCode] - Twilio error code if the message failed
- * @param {string} [reqBody.ErrorMessage] - Twilio error message if the message failed
+ * @param {object} smsData - Twilio SMS webhook request body
+ * @param {string} smsData.MessageSid - Unique identifier for the SMS message
+ * @param {string} smsData.MessageStatus - Status of the message (e.g., "delivered", "failed", "undelivered")
+ * @param {string} [smsData.ErrorCode] - Twilio error code if the message failed
+ * @param {string} [smsData.ErrorMessage] - Twilio error message if the message failed
  * @returns {Promise<void>}
  */
 const processTwilioEvent = async (reqBody) => {
@@ -6377,8 +6376,8 @@ const processTwilioEvent = async (reqBody) => {
       
       await doc.ref.update(eventRecord);
 
-      if (disableSmsErrorCodes.includes(eventErrorCode)) {
-        await updateSmsPermission(docData.phone, false);
+      if (disableSmsErrorCodes.includes(eventErrorCode) && docData.token) {
+        await updateSmsPermission([docData.token], false);
       }
     }
 
@@ -6389,6 +6388,37 @@ const processTwilioEvent = async (reqBody) => {
 
   if (!isRecordFound) {
     console.error(`Could not find notification record with messageSid ${reqBody.MessageSid}. Message status ${reqBody.MessageStatus}.`);
+  }
+};
+
+/**
+ * Stores an incoming Twilio SMS message in the "incomingSMS" Firestore collection.
+ * @param {object} smsData - Twilio incoming SMS webhook request body
+ * @param {string} smsData.From - Sender's phone number
+ * @param {string} [smsData.MessageSid] - Unique identifier for the SMS message
+ * @param {string} [smsData.To] - The phone number that received the SMS message (Twilio number)
+ * @param {string} [smsData.Body] - The content of the incoming SMS message
+ * @param {string} [smsData.SmsStatus] - The status of the SMS message (e.g., "received")
+ * @param {string} [smsData.OptOutType] - The type of opt-out event (e.g., START, STOP, HELP)
+ * @returns {Promise<void>}
+ * @throws {Error} If the Firestore write fails
+ */
+const storeIncomingSmsData = async (smsData = {}) => {
+  const { MessageSid, From, To, Body, SmsStatus, OptOutType } = smsData;
+  const smsRecord = {
+    [fieldMapping.smsSid]: MessageSid || "",
+    [fieldMapping.smsFrom]: From,
+    [fieldMapping.smsTo]: To || "",
+    [fieldMapping.smsContent]: Body || "",
+    [fieldMapping.smsStatus]: SmsStatus || "received",
+    ...(OptOutType && { [fieldMapping.smsOptOutType]: OptOutType }),
+    [fieldMapping.smsTimestamp]: new Date().toISOString(),
+  };
+
+  try {
+    await db.collection("incomingSMS").add(smsRecord);
+  } catch (error) {
+    throw new Error(`Error storing incoming SMS data for MessageSid ${MessageSid}.`, { cause: error });
   }
 };
 
@@ -6672,14 +6702,13 @@ const getAppSettings = async (appName, selectedParamsArray) => {
 
 /**
  *
- * @param {string} phoneNumber Phone number in +1XXXXXXXXXX format
+ * @param {string[]} tokenArray Tokens of participants to update
  * @param {boolean} isSmsPermitted Whether SMS is permitted or not
  * @returns {Promise<number>} Number of document(s) updated
  */
-const updateSmsPermission = async (phoneNumber, isSmsPermitted) => {
+const updateSmsPermission = async (tokenArray, isSmsPermitted) => {
   let count = 0;
   const permissionCid = isSmsPermitted ? fieldMapping.yes : fieldMapping.no;
-  const tokenArray = await getParticipantTokensByPhoneNumber(phoneNumber);
   if (tokenArray.length > 0) {
     const batch = db.batch();
     for (const token of tokenArray) {
@@ -7256,6 +7285,7 @@ module.exports = {
     getSupplyKitTrackingNumber,
     processSendGridEvent,
     processTwilioEvent,
+    storeIncomingSmsData,
     getSpecimenAndParticipant,
     queryKitsByReceivedDate,
     queryKitsByShippedAndAssignedStatus,

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -3090,7 +3090,7 @@ const handleIncomingSms = async (req, res) => {
     }
   } catch (error) {
       console.error("Error handling incoming message.", error);
-      return res.status(500).json(getResponseJSON(error.message || "Internal server error", 500));
+      return res.status(500).json(getResponseJSON("Internal server error", 500));
   }
 
   return res.sendStatus(204);

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -7,8 +7,8 @@ const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');
 const sharedUtils = require("./shared");
 const {getResponseJSON, setHeadersDomainRestricted, setHeaders, logIPAddress, redactEmailLoginInfo, redactPhoneLoginInfo, validEmailFormat, getTemplateForEmailLink, nihMailbox, getSecret, cidToLangMapper, unsubscribeTextObj, getAdjustedTime, getEasternDateKey, parseResponseJson, parseRequestBody, delay, backoffMs} = sharedUtils;
 const { htmlToPlaintext } = require("./htmlToPlaintext");
-const {getNotificationSpecById, getNotificationSpecByCategoryAndAttempt, getNotificationSpecsByScheduleOncePerDay, markNotificationSpecsQueuedForRun, clearNotificationSpecsQueuedRun, markNotificationSpecsLastRun, saveNotificationBatch, getNotificationRecordId, reserveNotificationBatch, markNotificationBatchProviderSendStarted, markNotificationBatchProviderAcceptanceUnknown, markNotificationBatchAccepted, markNotificationBatchFailed, generateSignInWithEmailLink, checkIsNotificationSent, updateSmsPermission, getEmailSuppressions, isEmailSuppressed, getAppSettings, getBulkNotificationRun, saveBulkNotificationRunPlan, getBulkNotificationBatch, getBulkNotificationRunBatches, markBulkNotificationBatchEnqueued, markBulkNotificationRunEnqueueFailed, markBulkNotificationRunQueued, markBulkNotificationBatchRunning, markBulkNotificationBatchComplete, markBulkNotificationBatchFailed, finalizeBulkNotificationRunIfTerminal } = require("./firestore");
-const {getParticipantsForNotificationsBQ, countParticipantsForNotificationsBQ} = require("./bigquery");
+const {getNotificationSpecById, getNotificationSpecByCategoryAndAttempt, getNotificationSpecsByScheduleOncePerDay, markNotificationSpecsQueuedForRun, clearNotificationSpecsQueuedRun, markNotificationSpecsLastRun, saveNotificationBatch, getNotificationRecordId, reserveNotificationBatch, markNotificationBatchProviderSendStarted, markNotificationBatchProviderAcceptanceUnknown, markNotificationBatchAccepted, markNotificationBatchFailed, generateSignInWithEmailLink, checkIsNotificationSent, updateSmsPermission, storeIncomingSmsData, getEmailSuppressions, isEmailSuppressed, getAppSettings, getBulkNotificationRun, saveBulkNotificationRunPlan, getBulkNotificationBatch, getBulkNotificationRunBatches, markBulkNotificationBatchEnqueued, markBulkNotificationRunEnqueueFailed, markBulkNotificationRunQueued, markBulkNotificationBatchRunning, markBulkNotificationBatchComplete, markBulkNotificationBatchFailed, finalizeBulkNotificationRunIfTerminal } = require("./firestore");
+const {getParticipantsForNotificationsBQ, countParticipantsForNotificationsBQ, getTokensAndPreferredLanguageByPhone} = require("./bigquery");
 const { normalizeEmailAddress, shouldFilterEmailAddress } = require("./emailSuppressionPolicy");
 const { isProviderSendStartedState } = require("./notificationState");
 const conceptIds = require("./fieldToConceptIdMapping");
@@ -3069,15 +3069,28 @@ const handleIncomingSms = async (req, res) => {
     return res.status(403).json(getResponseJSON("Invalid Twilio signature.", 403));
   }
 
-  const { OptOutType: optinOptoutType } = req.body;
-  if (["START", "STOP"].includes(optinOptoutType)) {
-    const isSmsPermitted = optinOptoutType === "START";
-    try {
-      await updateSmsPermission(req.body.From, isSmsPermitted);
-    } catch (error) {
-      console.error("Error updating SMS permission to 'participants' collection.", error);
-      return res.status(500).json(getResponseJSON("Internal server error", 500));
+  const smsData = req.body;
+  try {
+    await storeIncomingSmsData(smsData);
+    const { tokens, preferredLanguage } = await getTokensAndPreferredLanguageByPhone(smsData.From);
+
+    const optOutType = smsData.OptOutType || "";
+    if (["START", "STOP"].includes(optOutType)) {
+      const isSmsAllowed = optOutType === "START";
+      await updateSmsPermission(tokens, isSmsAllowed);
+    } else if (optOutType !== "HELP") {
+      const isSpanishPreferred = preferredLanguage === conceptIds.spanish;
+      const replyMessage = isSpanishPreferred
+        ? "Para ayuda, visite MyConnect.cancer.gov/support. Responda PARAR para cancelar su suscripción."
+        : "For help, visit MyConnect.cancer.gov/support. Reply STOP to unsubscribe.";
+      const messagingResponse = new twilio.twiml.MessagingResponse();
+      messagingResponse.message(replyMessage);
+
+      return res.status(200).type("text/xml").send(messagingResponse.toString());
     }
+  } catch (error) {
+      console.error("Error handling incoming message.", error);
+      return res.status(500).json(getResponseJSON(error.message || "Internal server error", 500));
   }
 
   return res.sendStatus(204);


### PR DESCRIPTION
This PR implements requirements in [issue#1576](https://github.com/episphere/connect/issues/1576), and also some code clean-up. Details:
- Store incoming messages in `incomingSMS` collection in Firestore
- Auto reply to messages not matching START, STOP or HELP as opt-out type, in English or Spanish depending on preferred language
- Sync `incomingSMS` collection to `Connect/incomingSMS` table, once per day
