### PR TITLE
Not storing `status` field of SMS data 

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -467,5 +467,8 @@ module.exports = {
     smsTo: 193005138,
     smsContent: 115707416,
     smsOptOutType: 689827049,
+    smsStart: 897758920,
+    smsStop: 194274197,
+    smsHelp: 227782304,
     smsTimestamp: 700108581,
 };

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -466,7 +466,6 @@ module.exports = {
     smsFrom: 756674860,
     smsTo: 193005138,
     smsContent: 115707416,
-    smsStatus: 432682375,
     smsOptOutType: 689827049,
     smsTimestamp: 700108581,
 };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -6398,13 +6398,12 @@ const processTwilioEvent = async (reqBody) => {
  * @param {string} [smsData.MessageSid] - Unique identifier for the SMS message
  * @param {string} [smsData.To] - The phone number that received the SMS message (Twilio number)
  * @param {string} [smsData.Body] - The content of the incoming SMS message
- * @param {string} [smsData.SmsStatus] - The status of the SMS message (e.g., "received")
  * @param {string} [smsData.OptOutType] - The type of opt-out event (e.g., START, STOP, HELP)
  * @returns {Promise<void>}
  * @throws {Error} If the Firestore write fails
  */
 const storeIncomingSmsData = async (smsData = {}) => {
-  const { MessageSid, From, To, Body, SmsStatus, OptOutType } = smsData;
+  const { MessageSid, From, To, Body, OptOutType } = smsData;
   if (!MessageSid || !From) {
     throw new Error('Missing required fields in incoming SMS data: MessageSid and From are required.');
   }
@@ -6414,7 +6413,6 @@ const storeIncomingSmsData = async (smsData = {}) => {
     [fieldMapping.smsFrom]: From,
     [fieldMapping.smsTo]: To || "",
     [fieldMapping.smsContent]: Body || "",
-    [fieldMapping.smsStatus]: SmsStatus || "received",
     ...(OptOutType && { [fieldMapping.smsOptOutType]: OptOutType }),
     [fieldMapping.smsTimestamp]: new Date().toISOString(),
   };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -6394,8 +6394,8 @@ const processTwilioEvent = async (reqBody) => {
 /**
  * Stores an incoming Twilio SMS message in the "incomingSMS" Firestore collection.
  * @param {object} smsData - Twilio incoming SMS webhook request body
+ * @param {string} smsData.MessageSid - Unique identifier for the SMS message
  * @param {string} smsData.From - Sender's phone number
- * @param {string} [smsData.MessageSid] - Unique identifier for the SMS message
  * @param {string} [smsData.To] - The phone number that received the SMS message (Twilio number)
  * @param {string} [smsData.Body] - The content of the incoming SMS message
  * @param {string} [smsData.OptOutType] - The type of opt-out event (e.g., START, STOP, HELP)
@@ -6408,12 +6408,18 @@ const storeIncomingSmsData = async (smsData = {}) => {
     throw new Error('Missing required fields in incoming SMS data: MessageSid and From are required.');
   }
 
+  const optOutKey = OptOutType ? `sms${OptOutType.charAt(0).toUpperCase() + OptOutType.slice(1).toLowerCase()}` : null;
+  let optOutCid = OptOutType;
+  if (optOutKey && fieldMapping[optOutKey]) {
+    optOutCid = fieldMapping[optOutKey];
+  }
+
   const smsRecord = {
     [fieldMapping.smsSid]: MessageSid,
     [fieldMapping.smsFrom]: From,
     [fieldMapping.smsTo]: To || "",
     [fieldMapping.smsContent]: Body || "",
-    ...(OptOutType && { [fieldMapping.smsOptOutType]: OptOutType }),
+    ...(OptOutType && { [fieldMapping.smsOptOutType]: optOutCid }),
     [fieldMapping.smsTimestamp]: new Date().toISOString(),
   };
 


### PR DESCRIPTION
This PR follows [PR#956](https://github.com/NCI-C4CP/connectFaas/pull/956):
 - Avoids storing `status` field as decided [here](https://github.com/episphere/connect/issues/1576#issuecomment-4732141151).
 - Use concept IDs for opt-out types