### PR TITLE
1682 fix

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3505,9 +3505,12 @@ const processRequestAKitConditions = async (updateDb, docId) => {
             const runTimestamp = new Date().toISOString();
 
             do {
+                const participantsInThisBatch = participantsToUpdate.slice(start, Math.min(start + maxSize, participantsToUpdate.length));
+                // If the count is a multiple of maxSize, there may be an extra final loop with an empty array, which will break if we try to run the query with it
+                if(!participantsInThisBatch.length) break;
                 batch = db.batch();
                 let query = db.collection('participants')
-                    .where('token', 'in', participantsToUpdate.slice(start, Math.min(start + maxSize, participantsToUpdate.length)))
+                    .where('token', 'in', participantsInThisBatch)
                     .select(`${collectionDetails}`);
 
                 


### PR DESCRIPTION
Updated processRequestAKitConditions loop to handle cases where the number of participants being updated is an exact multiple of 30. For [1682](https://github.com/episphere/connect/issues/1682).