### PR TITLE
API Key Generation

### DIFF
--- a/test/unit/iamEndpoints.test.js
+++ b/test/unit/iamEndpoints.test.js
@@ -1,0 +1,115 @@
+const httpMocks = require('node-mocks-http');
+const { setupTestSuite } = require('../shared/testHelpers');
+const { validateKeyCreation } = require('../../utils/iam');
+
+let dashboard;
+
+beforeAll(() => {
+    setupTestSuite({
+        setupConsole: false,
+        setupModuleMocks: true,
+    });
+
+    dashboard = require('../../utils/dashboard').dashboard;
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+const createDashboardRequest = (method, api, overrides = {}) => {
+    const { headers = {}, ...rest } = overrides;
+    return httpMocks.createRequest({
+        method,
+        query: { api },
+        headers: {
+            'x-forwarded-for': 'dummy',
+            ...headers,
+        },
+        connection: {},
+        ...rest,
+    });
+};
+
+describe('validateKeyCreation', () => {
+    it('should block when 2 active keys exist', () => {
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: true, expiresAt: null },
+            { keyId: 'key2', isLegacy: true, expiresAt: null },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('Maximum of 2');
+    });
+
+    it('should block when a non-legacy key has >2 weeks remaining', () => {
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 30);
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: false, expiresAt: futureDate.toISOString() },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('2 weeks');
+    });
+
+    it('should allow when a non-legacy key has <2 weeks remaining', () => {
+        const soonDate = new Date();
+        soonDate.setDate(soonDate.getDate() + 5);
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: false, expiresAt: soonDate.toISOString() },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(true);
+    });
+
+    it('should allow when only 1 legacy key exists (no 2-week check)', () => {
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: true, expiresAt: null },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(true);
+    });
+
+    it('should allow when 0 keys exist', () => {
+        const result = validateKeyCreation([]);
+        expect(result.allowed).toBe(true);
+    });
+
+    it('should block when 1 legacy + 1 non-legacy (2-key max)', () => {
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 60);
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: true, expiresAt: null },
+            { keyId: 'key2', isLegacy: false, expiresAt: futureDate.toISOString() },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('Maximum of 2');
+    });
+
+    it('should allow when 1 legacy + no other keys', () => {
+        const mockKeys = [
+            { keyId: 'key1', isLegacy: true, expiresAt: null },
+        ];
+        const result = validateKeyCreation(mockKeys);
+        expect(result.allowed).toBe(true);
+        expect(result.reason).toBeNull();
+    });
+});
+
+describe('dashboard IAM endpoint guards', () => {
+    it('should return 401 for listServiceAccountKeys without auth', async () => {
+        const req = createDashboardRequest('GET', 'listServiceAccountKeys');
+        const res = httpMocks.createResponse();
+        await dashboard(req, res);
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('should return 401 for generateServiceAccountKey without auth', async () => {
+        const req = createDashboardRequest('POST', 'generateServiceAccountKey');
+        const res = httpMocks.createResponse();
+        await dashboard(req, res);
+        expect(res.statusCode).toBe(401);
+    });
+});

--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -315,6 +315,25 @@ const dashboard = async (req, res) => {
         await updateMySamples(payload, action, userEmail);
         return res.status(200).json(getResponseJSON('Success!', 200));
 
+    } else if (api === 'listServiceAccountKeys') {
+        if (req.method !== 'GET') {
+            return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+        }
+
+        const saEmail = siteDetails.saEmail;
+        if (!saEmail) {
+            return res.status(400).json(getResponseJSON('No service account email configured for this site.', 400));
+        }
+
+        try {
+            const { listServiceAccountKeys } = require('./iam');
+            const keys = await listServiceAccountKeys(saEmail);
+            return res.status(200).json({ data: { keys }, code: 200 });
+        } catch (err) {
+            console.error('Error listing service account keys', err);
+            return res.status(500).json(getResponseJSON('Failed to list service account keys.', 500));
+        }
+
     } else if (api === 'generateServiceAccountKey') {
         if (req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
@@ -325,9 +344,45 @@ const dashboard = async (req, res) => {
             return res.status(400).json(getResponseJSON('No service account email configured for this site.', 400));
         }
 
-        const { createServiceAccountKey } = require('./iam');
-        const keyData = await createServiceAccountKey(saEmail);
-        return res.status(200).json({ data: keyData, code: 200 });
+        try {
+            const { createServiceAccountKey, listServiceAccountKeys, validateKeyCreation } = require('./iam');
+
+            const activeKeys = await listServiceAccountKeys(saEmail);
+            const validation = validateKeyCreation(activeKeys);
+            if (!validation.allowed) {
+                return res.status(409).json({ message: validation.reason, code: 409, data: { keys: activeKeys } });
+            }
+
+            const keyData = await createServiceAccountKey(saEmail);
+            const updatedKeys = await listServiceAccountKeys(saEmail);
+
+            try {
+                const { sendEmail } = require('./notifications');
+                const { getCoordinatingCenterEmail } = require('./firestore');
+                const { developmentTier } = require('./shared');
+                const cccEmail = await getCoordinatingCenterEmail();
+                if (cccEmail) {
+                    const siteAcronym = siteDetails.acronym || 'Unknown';
+                    const html = `<p>A new service account key was generated.</p>
+                        <ul>
+                            <li><strong>Tier:</strong> ${developmentTier}</li>
+                            <li><strong>Site:</strong> ${siteAcronym}</li>
+                            <li><strong>User:</strong> ${userEmail}</li>
+                            <li><strong>Service Account:</strong> ${saEmail}</li>
+                            <li><strong>Time:</strong> ${new Date().toISOString()}</li>
+                        </ul>`;
+                    await sendEmail(cccEmail, `[${developmentTier}] Service Account Key Created — ${siteAcronym}`, html);
+                }
+            } catch (notifyErr) {
+                console.error('CCC key creation notification failed (non-fatal)', notifyErr);
+            }
+
+            res.header('Cache-Control', 'no-store');
+            return res.status(200).json({ data: { keyData, keys: updatedKeys }, code: 200 });
+        } catch (err) {
+            console.error('Error generating service account key', err);
+            return res.status(500).json(getResponseJSON('Failed to generate service account key.', 500));
+        }
 
     } else {
         return res.status(404).json(getResponseJSON('API not found!', 404));

--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -315,6 +315,20 @@ const dashboard = async (req, res) => {
         await updateMySamples(payload, action, userEmail);
         return res.status(200).json(getResponseJSON('Success!', 200));
 
+    } else if (api === 'generateServiceAccountKey') {
+        if (req.method !== 'POST') {
+            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
+        }
+
+        const saEmail = siteDetails.saEmail;
+        if (!saEmail) {
+            return res.status(400).json(getResponseJSON('No service account email configured for this site.', 400));
+        }
+
+        const { createServiceAccountKey } = require('./iam');
+        const keyData = await createServiceAccountKey(saEmail);
+        return res.status(200).json({ data: keyData, code: 200 });
+
     } else {
         return res.status(404).json(getResponseJSON('API not found!', 404));
     }

--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -328,6 +328,7 @@ const dashboard = async (req, res) => {
         try {
             const { listServiceAccountKeys } = require('./iam');
             const keys = await listServiceAccountKeys(saEmail);
+            res.header('Cache-Control', 'no-store');
             return res.status(200).json({ data: { keys }, code: 200 });
         } catch (err) {
             console.error('Error listing service account keys', err);
@@ -346,6 +347,7 @@ const dashboard = async (req, res) => {
 
         try {
             const { createServiceAccountKey, listServiceAccountKeys, validateKeyCreation } = require('./iam');
+            res.header('Cache-Control', 'no-store');
 
             const activeKeys = await listServiceAccountKeys(saEmail);
             const validation = validateKeyCreation(activeKeys);
@@ -377,7 +379,6 @@ const dashboard = async (req, res) => {
                 console.error('CCC key creation notification failed (non-fatal)', notifyErr);
             }
 
-            res.header('Cache-Control', 'no-store');
             return res.status(200).json({ data: { keyData, keys: updatedKeys }, code: 200 });
         } catch (err) {
             console.error('Error generating service account key', err);

--- a/utils/iam.js
+++ b/utils/iam.js
@@ -68,7 +68,7 @@ const validateKeyCreation = (activeKeys) => {
         const timeRemaining = new Date(key.expiresAt) - new Date();
         if (timeRemaining > TWO_WEEKS_MS) {
             const expiresDate = new Date(key.expiresAt).toISOString().split('T')[0];
-            return { allowed: false, reason: `An active key still has more than 2 weeks before expiration (expires ${expiresDate}). New keys can only be created within 2 weeks of all existing keys expiring.` };
+            return { allowed: false, reason: `An active key still has more than 2 weeks before expiration (expires ${expiresDate}). New keys can only be created within 2 weeks of an existing non-legacy key expiring.` };
         }
     }
 

--- a/utils/iam.js
+++ b/utils/iam.js
@@ -1,21 +1,87 @@
 const { google } = require('googleapis');
 
+const LEGACY_KEY_THRESHOLD_YEARS = 1;
+const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
+
+const getIamClient = async () => {
+    const auth = new google.auth.GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    const authClient = await auth.getClient();
+    return google.iam({ version: 'v1', auth: authClient });
+};
+
+const isLegacyKey = (validBeforeTime) => {
+    if (!validBeforeTime) return true;
+    const expiry = new Date(validBeforeTime);
+    const threshold = new Date();
+    threshold.setFullYear(threshold.getFullYear() + LEGACY_KEY_THRESHOLD_YEARS);
+    return expiry > threshold;
+};
+
+/**
+ * Lists active USER_MANAGED keys for a service account with expiration info.
+ * @param {string} saEmail - The service account email address
+ * @returns {Promise<Array<object>>} Array of key info objects
+ */
+const listServiceAccountKeys = async (saEmail) => {
+    const iam = await getIamClient();
+
+    const response = await iam.projects.serviceAccounts.keys.list({
+        name: `projects/-/serviceAccounts/${saEmail}`,
+        keyTypes: ['USER_MANAGED'],
+    });
+
+    const keys = response.data.keys || [];
+    const now = new Date();
+
+    return keys
+        .filter(key => {
+            if (!key.validBeforeTime) return true;
+            return new Date(key.validBeforeTime) > now;
+        })
+        .map(key => {
+            const legacy = isLegacyKey(key.validBeforeTime);
+            const keyId = key.name.split('/').pop();
+            return {
+                keyId,
+                name: key.name,
+                createdAt: key.validAfterTime || null,
+                expiresAt: legacy ? null : key.validBeforeTime,
+                isLegacy: legacy,
+            };
+        });
+};
+
+/**
+ * Validates whether a new key can be created based on active key count and expiration.
+ * @param {Array<object>} activeKeys - Result from listServiceAccountKeys
+ * @returns {{ allowed: boolean, reason: string|null }}
+ */
+const validateKeyCreation = (activeKeys) => {
+    if (activeKeys.length >= 2) {
+        return { allowed: false, reason: 'Maximum of 2 active keys reached. Delete an existing key before creating a new one.' };
+    }
+
+    const nonLegacyKeys = activeKeys.filter(k => !k.isLegacy);
+    for (const key of nonLegacyKeys) {
+        const timeRemaining = new Date(key.expiresAt) - new Date();
+        if (timeRemaining > TWO_WEEKS_MS) {
+            const expiresDate = new Date(key.expiresAt).toISOString().split('T')[0];
+            return { allowed: false, reason: `An active key still has more than 2 weeks before expiration (expires ${expiresDate}). New keys can only be created within 2 weeks of all existing keys expiring.` };
+        }
+    }
+
+    return { allowed: true, reason: null };
+};
+
 /**
  * Creates a new service account key and returns the parsed JSON key file.
  * @param {string} saEmail - The service account email address from siteDetails.saEmail
  * @returns {Promise<object>} The parsed JSON key file object
  */
 const createServiceAccountKey = async (saEmail) => {
-    const auth = new google.auth.GoogleAuth({
-        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-    });
-
-    const authClient = await auth.getClient();
-
-    const iam = google.iam({
-        version: 'v1',
-        auth: authClient,
-    });
+    const iam = await getIamClient();
 
     const response = await iam.projects.serviceAccounts.keys.create({
         name: `projects/-/serviceAccounts/${saEmail}`,
@@ -24,14 +90,20 @@ const createServiceAccountKey = async (saEmail) => {
         },
     });
 
-    const privateKeyData = Buffer.from(response.data.privateKeyData, 'base64').toString();
-    const keyJson = JSON.parse(privateKeyData);
+    const { privateKeyData, name } = response.data || {};
+    if (!privateKeyData) {
+        throw new Error(`IAM key creation did not return privateKeyData for ${saEmail}`);
+    }
 
-    console.log(`Service account key created — saEmail: ${saEmail}, keyName: ${response.data.name}, time: ${new Date().toISOString()}`);
+    const keyJson = JSON.parse(Buffer.from(privateKeyData, 'base64').toString('utf8'));
+
+    console.log(`Service account key created — saEmail: ${saEmail}, keyName: ${name}, time: ${new Date().toISOString()}`);
 
     return keyJson;
 };
 
 module.exports = {
     createServiceAccountKey,
+    listServiceAccountKeys,
+    validateKeyCreation,
 };

--- a/utils/iam.js
+++ b/utils/iam.js
@@ -1,0 +1,37 @@
+const { google } = require('googleapis');
+
+/**
+ * Creates a new service account key and returns the parsed JSON key file.
+ * @param {string} saEmail - The service account email address from siteDetails.saEmail
+ * @returns {Promise<object>} The parsed JSON key file object
+ */
+const createServiceAccountKey = async (saEmail) => {
+    const auth = new google.auth.GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+
+    const authClient = await auth.getClient();
+
+    const iam = google.iam({
+        version: 'v1',
+        auth: authClient,
+    });
+
+    const response = await iam.projects.serviceAccounts.keys.create({
+        name: `projects/-/serviceAccounts/${saEmail}`,
+        requestBody: {
+            privateKeyType: 'TYPE_GOOGLE_CREDENTIALS_FILE',
+        },
+    });
+
+    const privateKeyData = Buffer.from(response.data.privateKeyData, 'base64').toString();
+    const keyJson = JSON.parse(privateKeyData);
+
+    console.log(`Service account key created — saEmail: ${saEmail}, keyName: ${response.data.name}, time: ${new Date().toISOString()}`);
+
+    return keyJson;
+};
+
+module.exports = {
+    createServiceAccountKey,
+};


### PR DESCRIPTION
Issue Addressed: https://github.com/episphere/connect/issues/1660

This pull request adds support for managing Google Cloud service account keys through new API endpoint handlers and utility functions. It introduces logic to list and create service account keys with important safeguards, and includes comprehensive unit tests for these features.

**New IAM Service Account Key Management Endpoints**

* `utils/dashboard.js`:
  * Adds two new API endpoints, `listServiceAccountKeys` and `generateServiceAccountKey`, to list and create service account keys for a site. These endpoints enforce HTTP method checks, validate service account configuration, and handle errors gracefully. Key creation is guarded by business logic to prevent exceeding limits and to ensure compliance with expiration policies. Notification emails are sent on key creation.