### PR TITLE
Cgr packages lost endpoint

### DIFF
--- a/config/yaml/getCgrPackagesLost.yaml
+++ b/config/yaml/getCgrPackagesLost.yaml
@@ -1,0 +1,40 @@
+steps:
+
+
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run',
+    'deploy',
+    '${_SERVICE}',
+    '--region=${_REGION}',
+    '--source=${_SOURCE}',
+    '--function=${_FUNCTION}',
+    '--base-image=${_BASE_IMAGE}',
+    '--memory=${_MEMORY}',
+    '--timeout=${_TIMEOUT}',
+    '--allow-unauthenticated',
+    '--env-vars-file=${_VARIABLES}'
+  ]
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: [
+    'run',
+    'services',
+    'add-iam-policy-binding',
+    '${_SERVICE}',
+    '--region=${_REGION}',
+    '--member=${_MEMBER}',
+    '--role=${_ROLE}'
+  ]
+
+substitutions:
+  _BASE_IMAGE: us-central1-docker.pkg.dev/serverless-runtimes/google-24-full/runtimes/nodejs24
+  _FUNCTION: getCgrPackagesLost
+  _MEMBER: allUsers
+  _MEMORY: 1024Mi
+  _REGION: us-central1
+  _ROLE: roles/run.invoker
+  _SERVICE: getcgrpackageslost
+  _SOURCE: .
+  _TIMEOUT: 240s

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { sendScheduledNotifications, processNotificationBatchBulkDefault, process
 const { connectApp } = require('./utils/connectApp');
 const { biospecimenAPIs } = require('./utils/biospecimen');
 const { incentiveCompleted, eligibleForIncentive } = require('./utils/incentive');
-const { getCgrPackagesInTransit } = require('./utils/cgrEndpoints');
+const { getCgrPackagesInTransit, getCgrPackagesLost } = require('./utils/cgrEndpoints');
 const { dashboard } = require('./utils/dashboard');
 const { importToBigQuery, firestoreExport, exportNotificationsToBucket } = require('./utils/events');
 const { participantDataCleanup } = require('./utils/participantDataCleanup');
@@ -29,6 +29,7 @@ exports.updateParticipantData = updateParticipantData;
 exports.getBigQueryData = getBigQueryData;
 exports.geocodedAddresses = geocodedAddresses;
 exports.getCgrPackagesInTransit = getCgrPackagesInTransit;
+exports.getCgrPackagesLost = getCgrPackagesLost;
 
 // End-Point for Site Manager Dashboard
 exports.dashboard = dashboard;

--- a/utils/cgrEndpoints.js
+++ b/utils/cgrEndpoints.js
@@ -15,7 +15,7 @@ const getCgrPackagesInTransit = async (req, res) => {
 
     try {
         const { cgrPackagesInTransit } = require('./firestore');
-        const response = await cgrPackagesInTransit(req.query.startDate, req.query.endDate);
+        const response = await cgrPackagesInTransit(req.query.startDate, req.query.endDate, 'exclude');
         return res.status(200).json({code: 200, ...response});
     } catch(err) {
         console.error('Error in getCgrPackagesInTransit', err);
@@ -24,6 +24,30 @@ const getCgrPackagesInTransit = async (req, res) => {
     
 }
 
+const getCgrPackagesLost = async (req, res) => {
+    logIPAddress(req);
+    setHeaders(res);
+
+    if (req.method !== 'GET') {
+        return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));
+    }
+
+    const authorized = await APIAuthorization(req);
+
+    if(authorized instanceof Error) return res.status(500).json(getResponseJSON(authorized.message, 500));
+    if(!authorized) return res.status(401).json(getResponseJSON('Authorization failed!', 401));
+
+    try {
+        const { cgrPackagesInTransit } = require('./firestore');
+        const response = await cgrPackagesInTransit(req.query.startDate, req.query.endDate, 'only');
+        return res.status(200).json({code: 200, ...response});
+    } catch(err) {
+        console.error('Error in getCgrPackagesInTransit', err);
+        return res.status(500).json({error: err.message || err, code: 500});
+    }
+}
+
 module.exports = {
-    getCgrPackagesInTransit
+    getCgrPackagesInTransit,
+    getCgrPackagesLost
 };

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2419,7 +2419,7 @@ const searchBoxesByLocation = async (institute, location) => {
             ]
         },]
  */
-const cgrPackagesInTransit = async (startDate, endDate) => {
+const cgrPackagesInTransit = async (startDate, endDate, getLostPackages = 'exclude') => {
 
     // Get helper methods
     const {
@@ -2434,6 +2434,10 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
     let boxQuery = db.collection('boxes')
         .where(fieldMapping.submitShipmentFlag.toString(), "==", fieldMapping.yes)
         .where(fieldMapping.siteShipmentReceived.toString(), "==", fieldMapping.no);
+
+    if(getLostPackages === 'only') {
+        boxQuery = boxQuery.where(fieldMapping.packageLost.toString(), '==', fieldMapping.yes);
+    }
     
 
     // Accepts any timestamp which is of a valid form for new Date(), including ISO timestamp, UTC string, Unix epoch, and locale string in UTC
@@ -2453,14 +2457,17 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
 
     const packages = pkgSnapshot.docs?.map(doc => doc.data()) || [];
 
-    // Filter out lost boxes to reflect the packages in transit
-    // Not included in the query because it excludes records where the field does not exist
-    const notLostBoxes = packages.filter(
-      (box) => box[fieldMapping.packageLost] !== fieldMapping.yes
-    );
+    let inTransitBoxes = packages;
+
+    if(getLostPackages === 'exclude') {
+        // Filter out lost boxes to reflect the packages in transit
+        // Not included in the query because it excludes records where the field does not exist
+        inTransitBoxes = packages.filter((box) => box[fieldMapping.packageLost] !== fieldMapping.yes);
+    }
+    
 
     // Sort the packages (getRecentBoxesShippedBySiteNotReceived in biospecimen)
-    const sortedPackages = notLostBoxes.sort((a,b) => {
+    const sortedPackages = inTransitBoxes.sort((a,b) => {
         const shipDateA = a[fieldMapping.submitShipmentTimestamp];
         const shipDateB = b[fieldMapping.submitShipmentTimestamp];
         return (shipDateA < shipDateB) ? 1 : -1;
@@ -2470,7 +2477,7 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
 
     const tubeIdSet = new Set();
     const collectionIdSet = new Set();
-    notLostBoxes.forEach(box => {
+    inTransitBoxes.forEach(box => {
         const bagKeys = Object.keys(box)
             .filter(key => bagConceptIdList.includes(parseInt(key, 10)))
             .sort((a, b) => {
@@ -2605,6 +2612,10 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
             biospecimens: []
         };
 
+        if(getLostPackages !== 'exclude' && shippedBox[fieldMapping.packageLost] === fieldMapping.yes) {
+            boxData.datePackageLost = shippedBox[fieldMapping.datePackageLost];
+        }
+
         bagKeys.forEach((bagId, index) => {
             const specimenBag = specimenBags[bagId];
             specimenBag[fieldMapping.samplesWithinBag]?.forEach((fullSpecimenId, j, specimenBagSize) => {
@@ -2613,7 +2624,6 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
                 let errors = '';
 
                 if (Object.prototype.hasOwnProperty.call(replacementTubeLabelObj,fullSpecimenId)) {
-                    console.log('Changing fullSpecimenId from %s to %s', fullSpecimenId, replacementTubeLabelObj[fullSpecimenId]);
                     fullSpecimenId = replacementTubeLabelObj[fullSpecimenId];
                 }
 
@@ -2626,15 +2636,29 @@ const cgrPackagesInTransit = async (startDate, endDate) => {
                     errors = `Could not find specimens for collection id ${collectionId}. This may happen when a specimen is deleted without removing it from the box. This is known to happen in dev and test environments, but should be reported if found in prod.`;
                     matchingSpecimen = {};
                 }
+                
                 const healthcareProvider = matchingSpecimen[fieldMapping.healthcareProvider] || "default";
                 const collectionTypeValue = matchingSpecimen[fieldMapping.collectionSetting];
+                if(collectionId === 'CXA071508') {
+                    console.log('Matching specimen for %s', collectionId, JSON.stringify(matchingSpecimen, null, '\t'));
+                    console.log('collectionTypeValue for specimen %s', collectionId, collectionTypeValue);
+                }
                 const collectionType = collectionTypeValue === fieldMapping.clinical ? 'clinical' : 'research';
+                if(collectionId === 'CXA071508') {
+                    console.log('collectionType for specimen %s', collectionId, collectionTypeValue);
+                }
+                if(collectionId === 'CXA071508') {
+                    console.log('collectionTypeValue === %s for specimen %s', fieldMapping.clinical, collectionId, collectionTypeValue === fieldMapping.clinical);
+                }
+                if(collectionId === 'CXA071508') {
+                    console.log('healthcareProvider for specimen %s', collectionId, matchingSpecimen[fieldMapping.healthCareProvider]);
+                }
                 const sampleCollectionCenterCode = collectionTypeValue === fieldMapping.clinical
-                        ? matchingSpecimen[fieldMapping.healthcareProvider] || ""
+                        ? matchingSpecimen[fieldMapping.healthCareProvider] || ""
                         : matchingSpecimen[fieldMapping.collectionLocation] || "";
                 const sampleCollectionCenter =
                     collectionTypeValue === fieldMapping.clinical
-                        ? clinicalCollectionLocationNameLookup[matchingSpecimen[fieldMapping.healthcareProvider]] || ""
+                        ? clinicalCollectionLocationNameLookup[matchingSpecimen[fieldMapping.healthCareProvider]] || ""
                         : researchCollectionLocationNameLookup[matchingSpecimen[fieldMapping.collectionLocation]] || "";
                 // Dummy date for clinical files requested in issue 936
                 const dateDrawn = collectionTypeValue === fieldMapping.clinical
@@ -5331,7 +5355,7 @@ const storeKitReceipt = async (pkg) => {
             }
             if (
                 participantDocData[fieldMapping.withdrawConsent] == fieldMapping.yes ||
-                participantDocData[fieldMapping.destroyData] == fieldMapping.yes ||
+                participantDocData[fieldMapping.participantMap.destroyData] == fieldMapping.yes ||
                 participantDocData?.[fieldMapping.activityParticipantRefusal]?.[fieldMapping.baselineMouthwashSample] === fieldMapping.yes ||
                 participantDocData?.[fieldMapping.activityParticipantRefusal]?.[fieldMapping.allFutureSamples] === fieldMapping.yes ||
                 participantDocData?.[fieldMapping.refusedAllFutureActivities] === fieldMapping.yes

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2402,22 +2402,41 @@ const searchBoxesByLocation = async (institute, location) => {
  * @param {String | Number} endDate Optional. Date in valid format to be passed into new Date(endDate).toISOString().
  * If provided, results are filtered to packages sent on or before this time.
  * @returns Array of form [{
-            "shipDate": "2026-06-22",
-            "trackingNumber": "665122232323",
-            "shippedSite": "NIH",
-            "shippedLocation": "Main Campus",
-            "shipDateTime": "2026-06-22T13:26:14.852Z",
-            "numSamples": 0,
+            "shipDate": "2026-07-15",
+            "trackingNumber": "774455511222",
+            "shippedSite": "HP",
+            "shippedLocation": "HP Park Nicollet",
+            "siteCode": 574368418,
+            "shipDateTime": "2026-07-15T22:31:50.212Z",
+            "numSamples": 1,
             "tempMonitor": "Yes",
-            "BoxId": "Box127",
+            "boxId": "Box8",
             "biospecimens": [
                 {
-                    "specimenBagId": "CXA088887 0008",
-                    "fullSpecimenIds": "CXA088887 0001",
-                    "materialType": "WHOLE BL"
-                },
-            ]
-        },]
+                    "studyId": "Connect Study",
+                    "specimenBagId": "CXA071510 0008",
+                    "fullSpecimenIds": "CXA071510 0001",
+                    "materialType": "WHOLE BL",
+                    "sampleCollectionCenter": "HealthPartners Clinical",
+                    "sampleCollectionCenterCode": 531629870,
+                    "sampleId": "CXA071510",
+                    "sequence": "0001",
+                    "subjectId": 2386926968,
+                    "dateDrawn": "01/01/1999 12:00:00 PM",
+                    "vialType": "5 ml Serum separator tube",
+                    "additivePreservative": "SST",
+                    "volume": "5",
+                    "volumeEstimate": "Assumed",
+                    "volumeUnit": "ml (cc)",
+                    "vialWarnings": "",
+                    "hemolyzed": "",
+                    "labelStatus": "Barcoded",
+                    "visit": "BL",
+                    "errors": ""
+                }, ...
+            ],
+            "datePackageLost": "2026-03-11T17:35:03.487Z" // Included only for packages which have been marked as lost
+        }, ...]
  */
 const cgrPackagesInTransit = async (startDate, endDate, getLostPackages = 'exclude') => {
 
@@ -2636,24 +2655,10 @@ const cgrPackagesInTransit = async (startDate, endDate, getLostPackages = 'exclu
                     errors = `Could not find specimens for collection id ${collectionId}. This may happen when a specimen is deleted without removing it from the box. This is known to happen in dev and test environments, but should be reported if found in prod.`;
                     matchingSpecimen = {};
                 }
-                const healthcareProvider = matchingSpecimen[fieldMapping.healthCareProvider] || "default";
                 
-                const healthcareProvider = matchingSpecimen[fieldMapping.healthcareProvider] || "default";
+                const healthcareProvider = matchingSpecimen[fieldMapping.healthCareProvider] || "default";
                 const collectionTypeValue = matchingSpecimen[fieldMapping.collectionSetting];
-                if(collectionId === 'CXA071508') {
-                    console.log('Matching specimen for %s', collectionId, JSON.stringify(matchingSpecimen, null, '\t'));
-                    console.log('collectionTypeValue for specimen %s', collectionId, collectionTypeValue);
-                }
                 const collectionType = collectionTypeValue === fieldMapping.clinical ? 'clinical' : 'research';
-                if(collectionId === 'CXA071508') {
-                    console.log('collectionType for specimen %s', collectionId, collectionTypeValue);
-                }
-                if(collectionId === 'CXA071508') {
-                    console.log('collectionTypeValue === %s for specimen %s', fieldMapping.clinical, collectionId, collectionTypeValue === fieldMapping.clinical);
-                }
-                if(collectionId === 'CXA071508') {
-                    console.log('healthcareProvider for specimen %s', collectionId, matchingSpecimen[fieldMapping.healthCareProvider]);
-                }
                 const sampleCollectionCenterCode = collectionTypeValue === fieldMapping.clinical
                         ? matchingSpecimen[fieldMapping.healthCareProvider] || ""
                         : matchingSpecimen[fieldMapping.collectionLocation] || "";

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -3011,149 +3011,10 @@ const researchCollectionLocationNameLookup =
     [fieldMapping.nameToKeyObj.killeenMain]: "Killeen Main",
     [fieldMapping.nameToKeyObj.wacoFishpond]: "Waco Fishpond",
     111111111: "NIH",
-    13: "NCI"
+    222222222: "NIH-2", // This is a dev-only location, but is included for dev testing purposes
+    13: "NCI",
 
 }
-
-// Vial type mapping (date-dependent due to changeover)
-
-const vialMappingHistory = [
-    { //mapping20251009
-        effectiveDate: "2025-10-30", // Note: This mapping will be shown in Production on 2025-10-29.
-        research: {
-            default: {
-                "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0002": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0003": ["10 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "10"],
-                "0004": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0007": ["15ml Nalgene jar", "Crest Alcohol Free", "Saliva", "15"],
-                "0060": ["Streck Tube", "Streck Nucleic Acid", "WHOLE BL", "10"],
-            },
-        },
-        clinical: {
-            henryFordHealth: {
-                "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0002": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0003": ["10 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "10"],
-                "0004": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0060": ["Streck Tube", "Streck Nucleic Acid", "WHOLE BL", "10"],
-            },
-            healthPartners: {
-                "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0002": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0003": ["10 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "10"],
-                "0004": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0060": ["Streck Tube", "Streck Nucleic Acid", "WHOLE BL", "10"],
-            },
-            kpCO: {
-                "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0002": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0011": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0012": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0003": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0013": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0004": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0014": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["6 ml Vacutainer", "No Additive", "Urine", "6"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-            },
-            kpGA: {
-                "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0002": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0011": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0012": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0003": ["4.5 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4.5"],
-                "0013": ["4.5 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4.5"],
-                "0004": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0014": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-            },
-            kpHI: {
-                "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0002": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0011": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0012": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0003": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0013": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0004": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0014": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0024": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-            },
-            kpNW: {
-                "0001": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
-                "0002": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
-                "0011": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
-                "0012": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
-                "0021": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
-                "0003": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0013": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0004": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0014": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-            },
-            sanfordHealth: {
-                "0001": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0002": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0011": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0012": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0003": [
-                    "4.5 ml Vacutainer",
-                    "Lithium Heparin Separator",
-                    "Plasma",
-                    "4.5",
-                ],
-                "0013": [
-                    "4.5 ml Vacutainer",
-                    "Lithium Heparin Separator",
-                    "Plasma",
-                    "4.5",
-                ],
-                "0004": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0014": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0024": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-            },
-            uOfChicagoMed: {
-                "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0002": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
-                "0003": ["10 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "10"],
-                "0004": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-            },
-            default: {
-                "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0002": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0011": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0012": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0021": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
-                "0003": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0013": ["4 ml Vacutainer", "Lithium Heparin", "WHOLE BL", "4"],
-                "0004": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0014": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0024": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
-                "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
-                "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
-                "0007": ["15ml Nalgene jar", "Crest Alcohol Free", "Saliva", "15"],
-                "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
-            },
-        }
-    }
-]
 
 const conceptIdToHealthProviderAbbrObj = {
   452412599: "kpNW",
@@ -3192,6 +3053,12 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
                 "0060": ["Streck Tube", "Streck Nucleic Acid", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0011": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0012": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0021": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0014": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
+                "0024": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"]
             },
             healthPartners: {
                 "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
@@ -3201,6 +3068,12 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
                 "0060": ["Streck Tube", "Streck Nucleic Acid", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0011": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0012": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0021": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],
+                "0014": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"],
+                "0024": ["10 ml Vacutainer", "EDTA = K2", "WHOLE BL", "10"]
             },
             kpCO: {
                 "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
@@ -3214,6 +3087,9 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["6 ml Vacutainer", "No Additive", "Urine", "6"],
                 "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0021": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
+                "0024": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
             },
             kpGA: {
                 "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
@@ -3227,6 +3103,9 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
                 "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0021": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
+                "0024": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
             },
             kpHI: {
                 "0001": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
@@ -3241,6 +3120,8 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
                 "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0021": ["5 ml Serum separator tube", "SST", "WHOLE BL", "5"],
             },
             kpNW: {
                 "0001": ["3.5 ml Serum separator tube", "SST", "WHOLE BL", "3.5"],
@@ -3255,6 +3136,8 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0005": ["6 ml Vacutainer", "ACD", "WHOLE BL", "6"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
                 "0060": ["Streck Tube", "Streck DNA", "WHOLE BL", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0024": ["4 ml Vacutainer", "EDTA = K2", "WHOLE BL", "4"],
             },
             sanfordHealth: {
                 "0001": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
@@ -3277,6 +3160,8 @@ const getVialTypesMappings = (tubeId, collectionType, healthcareProvider) => {
                 "0014": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
                 "0024": ["3 ml Vacutainer", "EDTA = K2", "WHOLE BL", "3"],
                 "0006": ["10 ml Vacutainer", "No Additive", "Urine", "10"],
+                // These tubes are not usually collected by this site, but are included for thoroughness
+                "0021": ["5 mL Serum separator tube", "SST", "WHOLE BL", "5"],
             },
             uOfChicagoMed: {
                 "0001": ["10 ml Serum separator tube", "SST", "WHOLE BL", "10"],


### PR DESCRIPTION
Further updates for [1655](https://github.com/episphere/connect/issues/1655)

* Adds a new getCgrPackagesLost endpoint and function
* New functionality and bugfixes for cgrPackagesInTransit
* Adds some additional constants for edge cases when looking up vial information

Changes:

getCgrPackagesLost.yaml:
* File created
* 
cgrEndpoints.js:
* getCgrPackagesLost function added

index.js:
* getCgrPackagesLost functionality added

firestore.js:
* Updates the JSDoc for cgrPackagesInTransit to reflect additional information being returned
* Updates cgrPackagesInTransit to permit retrieving lost packages based on an additional parameter
* Fixed a remaining instance of referencing healthcareProvider instead of healthCareProvider

shared.js:
* Removed unused constant
* Added possible extra tubes for clinical collection sites so that, if included outside of the usual process, they will still report the correct tube information
* Added an additional dev-only location to the collection name lookup so dev testing results will not have a site that appears to be invalid.