### PR TITLE
Diet Screener should be set to notStarted at the time of verification

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -559,6 +559,8 @@ module.exports = {
     dhq3ResponseProcessedTime: 262294850,
     dhq3ProcessedRespondentArray: 116442364,
 
+    dietScreenerSurveyStatus: 301686481,
+
     // Pathology Reports
     pathologyReportFilename: 488064292,
 

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -858,7 +858,7 @@ const cleanSurveyData = (data) => {
 const checkSurveyStatusesWhenVerified = (payloadData, docData) => {
     if (payloadData[fieldMapping.verificationStatus] !== fieldMapping.verified) return payloadData;
 
-    const statusesToCheck = [fieldMapping.cancerScreeningHistorySurveyStatus, fieldMapping.dhq3SurveyStatus];
+    const statusesToCheck = [fieldMapping.cancerScreeningHistorySurveyStatus, fieldMapping.dhq3SurveyStatus, fieldMapping.dietScreenerSurveyStatus];
 
     for (const statusKey of statusesToCheck) {
         if (!docData[statusKey]) {


### PR DESCRIPTION
For Issue 1550: https://github.com/episphere/connect/issues/1550
Per the spec the Diet Screener survey should be marked as notStarted at the time the user is verified