### PR TITLE
Add protobufjs 7.5.6 overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "connectfaas",
       "version": "1.0.0",
       "license": "ISC",
-      "engines": {
-        "node": "24"
-      },
       "dependencies": {
         "@google-cloud/bigquery": "^7.3.0",
         "@google-cloud/firestore": "^7.1.0",
@@ -34,6 +31,9 @@
         "@vitest/coverage-v8": "^4.0.18",
         "node-mocks-http": "^1.16.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": "24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -950,10 +950,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -978,10 +977,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -996,10 +994,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -4176,22 +4173,21 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "picomatch": "4.0.4 for CVE-2026-33671 (GHSA-c2c7-rcm5-vvqj), CVE-2026-33672 (GHSA-3v7f-55p6-f55p)",
     "axios": "1.13.5 for GHSA-43fc-jf86-j433 (DoS via __proto__ in mergeConfig)",
     "path-to-regexp": "0.1.13 for CVE-2026-4867 / GHSA-37ch-88jc-xwx2 (ReDoS via 3+ route params)",
-    "ajv": "8.18.0 for CVE-2025-69873 / GHSA-2g4f-4pwh-qvx6 (ReDoS with $data option)"
+    "ajv": "8.18.0 for CVE-2025-69873 / GHSA-2g4f-4pwh-qvx6 (ReDoS with $data option)",
+    "protobufjs": "7.5.6 for CVE-2026-44291 / GHSA-75px-5xx7-5xc7 (code execution following prototype pollution)"
   },
   "overrides": {
     "diff": "8.0.3",
@@ -73,6 +74,7 @@
     "node-forge": "1.4.0",
     "path-to-regexp": "0.1.13",
     "ajv": "8.18.0",
+    "protobufjs": "7.5.6",
     "@google-cloud/bigquery": {
       "form-data": "2.5.5"
     },


### PR DESCRIPTION
The protobufjs 7.6.3 version is the highest patch in the list below

Dependabot patch list recommendations:
-  https://github.com/NCI-C4CP/connectFaas/security/dependabot/124
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/150
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/152
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/154
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/149
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/175
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/153
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/148
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/151
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/158
- https://github.com/NCI-C4CP/connectFaas/security/dependabot/174

Code Changes 
- Added protobufjs 7.6.3 to overrides
- Updated `package.json` and `package-lock.json`